### PR TITLE
Add logging.

### DIFF
--- a/spikewrap/data_classes/preprocessing.py
+++ b/spikewrap/data_classes/preprocessing.py
@@ -67,6 +67,7 @@ class PreprocessingData(BaseUserDict):
         self.data: Dict = {"0-raw": None}
         self.sync = None
 
+        self.logging_path = utils.get_logging_path(self.base_path, self.sub_name)
         self.preprocessed_data_path: Path
         self._pp_data_attributes_path: Path
         self._pp_binary_data_path: Path

--- a/spikewrap/data_classes/preprocessing.py
+++ b/spikewrap/data_classes/preprocessing.py
@@ -67,7 +67,7 @@ class PreprocessingData(BaseUserDict):
         self.data: Dict = {"0-raw": None}
         self.sync = None
 
-        self.logging_path = utils.get_logging_path(self.base_path, self.sub_name)
+        self.logging_path = self.get_logging_path()
         self.preprocessed_data_path: Path
         self._pp_data_attributes_path: Path
         self._pp_binary_data_path: Path
@@ -388,3 +388,8 @@ class PreprocessingData(BaseUserDict):
                 f"in run name {name}. "
             )
         return base_path, run_names, rawdata_path
+
+    def get_logging_path(self):
+        return (
+            self.base_path / "derivatives" / self.sub_name / self.pp_run_name / "logs"
+        )

--- a/spikewrap/data_classes/sorting.py
+++ b/spikewrap/data_classes/sorting.py
@@ -53,7 +53,7 @@ class SortingData(BaseUserDict):
         self.pp_run_name = self.pp_info["pp_run_name"]
 
         # TODO: duplication from processing(). Figure out inheritance
-        self.logging_path = utils.get_logging_path(self.base_path, self.sub_name)
+        self.logging_path = self.get_logging_path()
 
         # These paths are set when the sorter
         # is known, set_sorter_output_paths()
@@ -162,4 +162,9 @@ class SortingData(BaseUserDict):
         )
         self.unit_locations_path = (
             self.postprocessing_output_path / "unit_locations.csv"
+        )
+
+    def get_logging_path(self):
+        return (
+            self.base_path / "derivatives" / self.sub_name / self.pp_run_name / "logs"
         )

--- a/spikewrap/data_classes/sorting.py
+++ b/spikewrap/data_classes/sorting.py
@@ -52,6 +52,9 @@ class SortingData(BaseUserDict):
         self.sub_name = self.pp_info["sub_name"]
         self.pp_run_name = self.pp_info["pp_run_name"]
 
+        # TODO: duplication from processing(). Figure out inheritance
+        self.logging_path = utils.get_logging_path(self.base_path, self.sub_name)
+
         # These paths are set when the sorter
         # is known, set_sorter_output_paths()
         self.sorter_base_output_path: Path

--- a/spikewrap/examples/example_full_pipeline.py
+++ b/spikewrap/examples/example_full_pipeline.py
@@ -3,8 +3,8 @@ from pathlib import Path
 from spikewrap.pipeline.full_pipeline import run_full_pipeline
 
 base_path = Path(
-    # r"C:\data\ephys\test_data\steve_multi_run\1119617\time-short"
-    "/ceph/neuroinformatics/neuroinformatics/scratch/jziminski/ephys/test_data/steve_multi_run/1119617/time-short"
+    r"C:\data\ephys\test_data\steve_multi_run\1119617\time-short"
+    # "/ceph/neuroinformatics/neuroinformatics/scratch/jziminski/ephys/test_data/steve_multi_run/1119617/time-short"
 )
 sub_name = "1119617"
 run_names = [
@@ -23,7 +23,7 @@ if __name__ == "__main__":
         run_names,
         config_name,
         sorter,
-        existing_preprocessed_data="overwrite",
+        existing_preprocessed_data="load_if_exists",
         existing_sorting_output="overwrite",
         overwrite_postprocessing=True,
         slurm_batch=False,

--- a/spikewrap/examples/example_full_pipeline.py
+++ b/spikewrap/examples/example_full_pipeline.py
@@ -3,8 +3,8 @@ from pathlib import Path
 from spikewrap.pipeline.full_pipeline import run_full_pipeline
 
 base_path = Path(
-    r"C:\data\ephys\test_data\steve_multi_run\1119617\time-short"
-    # "/ceph/neuroinformatics/neuroinformatics/scratch/jziminski/ephys/test_data/steve_multi_run/1119617/time-short"
+    # r"C:\data\ephys\test_data\steve_multi_run\1119617\time-short"
+    "/ceph/neuroinformatics/neuroinformatics/scratch/jziminski/ephys/test_data/steve_multi_run/1119617/time-short"
 )
 sub_name = "1119617"
 run_names = [

--- a/spikewrap/examples/example_visualise.py
+++ b/spikewrap/examples/example_visualise.py
@@ -1,3 +1,4 @@
+from spikewrap.pipeline.preprocess import preprocess
 from spikewrap.pipeline.visualise import visualise
 from spikewrap.pipline.load_data import load_data
 
@@ -7,8 +8,10 @@ run_names = "1119617_LSE1_shank12"
 
 data = load_data.load_data(base_path, sub_name, run_names, "spikeglx")
 
+preprocess_data = preprocess(data, pp_steps="default")
+
 visualise(
-    data,
+    preprocess_data,
     steps=["all"],
     mode="map",
     as_subplot=True,

--- a/spikewrap/examples/example_visualise.py
+++ b/spikewrap/examples/example_visualise.py
@@ -1,14 +1,11 @@
-from spikewrap.pipeline.load_data import load_spikeglx_data
-from spikewrap.pipeline.preprocess import preprocess
 from spikewrap.pipeline.visualise import visualise
+from spikewrap.pipline.load_data import load_data
 
 base_path = r"X:\neuroinformatics\scratch\jziminski\ephys\test_data\steve_multi_run\1119617\time-short"
 sub_name = "1119617"
 run_names = "1119617_LSE1_shank12"
 
-data = load_spikeglx_data(base_path, sub_name, run_names)
-
-data = preprocess(data, pp_steps="default")
+data = load_data.load_data(base_path, sub_name, run_names, "spikeglx")
 
 visualise(
     data,

--- a/spikewrap/pipeline/full_pipeline.py
+++ b/spikewrap/pipeline/full_pipeline.py
@@ -132,18 +132,18 @@ def run_full_pipeline(
 
     pp_steps, sorter_options, waveform_options = get_configs(config_name)
 
-    logs = logging_sw.get_started_logger(
-        utils.get_logging_path(Path(base_path), sub_name), "full_pipeline"
-    )
+    data_class = PreprocessingData(base_path, sub_name, run_names)
 
-    preprocess_data = load_spikeglx_data(base_path, sub_name, run_names)
+    logs = logging_sw.get_started_logger(data_class.logging_path, "full_pipeline")
 
-    preprocess_and_save(preprocess_data, pp_steps, existing_preprocessed_data, verbose)
+    loaded_data = load_spikeglx_data(data_class)
 
-    expected_sorter_path = preprocess_data.get_expected_sorter_path(sorter) / "sorting"
+    preprocess_and_save(loaded_data, pp_steps, existing_preprocessed_data, verbose)
+
+    expected_sorter_path = loaded_data.get_expected_sorter_path(sorter) / "sorting"
 
     sorting_data = load_or_run_sorting(
-        preprocess_data.preprocessed_data_path,
+        loaded_data.preprocessed_data_path,
         expected_sorter_path,
         existing_sorting_output,
         sorter,

--- a/spikewrap/pipeline/full_pipeline.py
+++ b/spikewrap/pipeline/full_pipeline.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Dict, List, Literal, Tuple, Union
 
 from ..configs.configs import get_configs
+from ..data_classes.preprocessing import PreprocessingData
 from ..pipeline.load_data import load_data_for_sorting
 from ..utils import logging_sw, slurm, utils
 from ..utils.custom_types import HandleExisting
@@ -17,7 +18,6 @@ from .preprocess import preprocess
 from .sort import run_sorting
 
 if TYPE_CHECKING:
-    from ..data_classes.preprocessing import PreprocessingData
     from ..data_classes.sorting import SortingData
 
 
@@ -236,7 +236,8 @@ def load_or_run_sorting(
 ) -> SortingData:
     """
     Handle existing sorting output. If previous output exists, load, error or
-    overwrite according to `existing_sorting_output`. See `run_full_pipeline()` for details.
+    overwrite according to `existing_sorting_output`.
+    See `run_full_pipeline()` for details.
     """
     if expected_sorter_path.is_dir() and existing_sorting_output == "load_if_exists":
         utils.message_user(

--- a/spikewrap/pipeline/full_pipeline.py
+++ b/spikewrap/pipeline/full_pipeline.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, Dict, List, Literal, Tuple, Union
 
 from ..configs.configs import get_configs
 from ..pipeline.load_data import load_data_for_sorting
-from ..utils import slurm, utils
+from ..utils import logging_sw, slurm, utils
 from ..utils.custom_types import HandleExisting
 from .load_data import load_spikeglx_data
 from .postprocess import run_postprocess
@@ -132,6 +132,10 @@ def run_full_pipeline(
 
     pp_steps, sorter_options, waveform_options = get_configs(config_name)
 
+    logs = logging_sw.get_started_logger(
+        utils.get_logging_path(Path(base_path), sub_name), "full_pipeline"
+    )
+
     preprocess_data = load_spikeglx_data(base_path, sub_name, run_names)
 
     preprocess_and_save(preprocess_data, pp_steps, existing_preprocessed_data, verbose)
@@ -160,6 +164,8 @@ def run_full_pipeline(
     )
 
     handle_delete_intermediate_files(sorting_data, delete_intermediate_files)
+
+    logs.stop_logging()
 
 
 def handle_delete_intermediate_files(sorting_data, delete_intermediate_files):

--- a/spikewrap/pipeline/load_data.py
+++ b/spikewrap/pipeline/load_data.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, List, Union
+from typing import TYPE_CHECKING
 
 import spikeinterface.extractors as se
 from spikeinterface import append_recordings
@@ -12,9 +12,14 @@ if TYPE_CHECKING:
     from pathlib import Path
 
 
-def load_spikeglx_data(
-    base_path: Union[Path, str], sub_name: str, run_names: Union[List[str], str]
-) -> PreprocessingData:
+def load_data(base_path, sub_name, run_name, type="spikeglx"):
+    """TODO: can get type from data itself"""
+    preprocess_data = PreprocessingData(base_path, sub_name, run_name)
+    if type == "spikeglx":
+        return load_spikeglx_data(preprocess_data)
+
+
+def load_spikeglx_data(preprocess_data: PreprocessingData) -> PreprocessingData:
     """
     Load raw SpikeGLX data (in rawdata). If multiple runs are selected
     in run_names, these will be stored as segments on a SpikeInterface
@@ -40,8 +45,6 @@ def load_spikeglx_data(
     PreprocessingData class containing SpikeInterface recording object and information
     on the data filepaths.
     """
-    preprocess_data = PreprocessingData(base_path, sub_name, run_names)
-
     all_recordings = []
     all_sync = []
     for run_path in preprocess_data.all_run_paths:

--- a/spikewrap/pipeline/load_data.py
+++ b/spikewrap/pipeline/load_data.py
@@ -7,21 +7,15 @@ from spikeinterface import append_recordings
 
 from ..data_classes.preprocessing import PreprocessingData
 from ..data_classes.sorting import SortingData
+from ..utils import utils
 
 if TYPE_CHECKING:
     from pathlib import Path
 
 
-def load_data(base_path, sub_name, run_name, type="spikeglx"):
-    """TODO: can get type from data itself"""
-    preprocess_data = PreprocessingData(base_path, sub_name, run_name)
-    if type == "spikeglx":
-        return load_spikeglx_data(preprocess_data)
-
-
-def load_spikeglx_data(preprocess_data: PreprocessingData) -> PreprocessingData:
+def load_data(base_path, sub_name, run_names, data_format="spikeglx"):
     """
-    Load raw SpikeGLX data (in rawdata). If multiple runs are selected
+    Load raw data (in rawdata). If multiple runs are selected
     in run_names, these will be stored as segments on a SpikeInterface
     recording object.
 
@@ -39,32 +33,24 @@ def load_spikeglx_data(preprocess_data: PreprocessingData) -> PreprocessingData:
         The SpikeGLX run name (i.e. not including the gate index). This can
         also be a list of run names.
 
+    data_format : str
+        The data type format to load. Currently only "spikeglx" is accepted.
+
     Returns
     -------
 
     PreprocessingData class containing SpikeInterface recording object and information
     on the data filepaths.
+
+    TODO
+    ----
+    Figure out the format from the data itself, instead of passing as argument.
+    Do this when adding the next supported format.
     """
-    all_recordings = []
-    all_sync = []
-    for run_path in preprocess_data.all_run_paths:
-        with_sync, without_sync = [
-            se.read_spikeglx(
-                folder_path=run_path,
-                stream_id="imec0.ap",
-                all_annotations=True,
-                load_sync_channel=sync,
-            )
-            for sync in [True, False]
-        ]
-        all_recordings.append(without_sync)
-        sync_channel_id = with_sync.get_channel_ids()[-1]
-        all_sync.append(with_sync.channel_slice(channel_ids=[sync_channel_id]))
+    empty_data_class = PreprocessingData(base_path, sub_name, run_names)
 
-    preprocess_data["0-raw"] = append_recordings(all_recordings)
-    preprocess_data.sync = append_recordings(all_sync)
-
-    return preprocess_data
+    if data_format == "spikeglx":
+        return load_spikeglx_data(empty_data_class)
 
 
 def load_data_for_sorting(
@@ -104,3 +90,42 @@ def load_data_for_sorting(
     sorting_data.load_preprocessed_binary(concatenate)
 
     return sorting_data
+
+
+# --------------------------------------------------------------------------------------
+# Format-specific Loaders
+# --------------------------------------------------------------------------------------
+
+
+def load_spikeglx_data(preprocess_data: PreprocessingData) -> PreprocessingData:
+    """
+    Load raw SpikeGLX data (in rawdata). If multiple runs are selected
+    in run_names, these will be stored as segments on a SpikeInterface
+    recording object.
+
+    See load_data() for parameters.
+    """
+    all_recordings = []
+    all_sync = []
+    for run_path in preprocess_data.all_run_paths:
+        with_sync, without_sync = [
+            se.read_spikeglx(
+                folder_path=run_path,
+                stream_id="imec0.ap",
+                all_annotations=True,
+                load_sync_channel=sync,
+            )
+            for sync in [True, False]
+        ]
+        all_recordings.append(without_sync)
+        sync_channel_id = with_sync.get_channel_ids()[-1]
+        all_sync.append(with_sync.channel_slice(channel_ids=[sync_channel_id]))
+
+    preprocess_data["0-raw"] = append_recordings(all_recordings)
+    preprocess_data.sync = append_recordings(all_sync)
+
+    utils.message_user(
+        f"Raw session data was loaded from " f"{preprocess_data.all_run_paths}"
+    )
+
+    return preprocess_data

--- a/spikewrap/pipeline/postprocess.py
+++ b/spikewrap/pipeline/postprocess.py
@@ -16,7 +16,7 @@ from spikeinterface.extractors import NpzSortingExtractor
 from ..configs.configs import get_configs
 from ..data_classes.sorting import SortingData
 from ..pipeline.load_data import load_data_for_sorting
-from ..utils import utils
+from ..utils import logging_sw, utils
 from ..utils.custom_types import HandleExisting
 from .waveform_compare import get_waveform_similarity
 
@@ -96,6 +96,8 @@ def run_postprocess(
         )
     assert isinstance(sorting_data, SortingData), "type narrow `sorting_data`."
 
+    logs = logging_sw.get_started_logger(sorting_data.logging_path, "postprocess")
+
     # Create / load waveforms
     if waveform_options is None:
         _, _, waveform_options = get_configs("default")
@@ -127,6 +129,8 @@ def run_postprocess(
         save_waveform_similarities(
             sorting_data.postprocessing_output_path, waveforms, MATRIX_BACKEND
         )
+
+    logs.stop_logging()
 
 
 # Sorting Loader -----------------------------------------------------------------------

--- a/spikewrap/pipeline/preprocess.py
+++ b/spikewrap/pipeline/preprocess.py
@@ -47,8 +47,6 @@ def preprocess(
         associated SpikeInterface recording objects.
 
     """
-    # 1) get base dir from preproces_data / sorting data
-    # 2) addition of date, function name (make a utils in logging_sw)
     logs = logging_sw.get_started_logger(preprocess_data.logging_path, "preprocess")
 
     if isinstance(pp_steps, str):

--- a/spikewrap/pipeline/preprocess.py
+++ b/spikewrap/pipeline/preprocess.py
@@ -6,7 +6,7 @@ import spikeinterface.preprocessing as spre
 
 from ..configs import configs
 from ..data_classes.preprocessing import PreprocessingData
-from ..utils import utils
+from ..utils import logging_sw, utils
 
 
 def preprocess(
@@ -47,6 +47,10 @@ def preprocess(
         associated SpikeInterface recording objects.
 
     """
+    # 1) get base dir from preproces_data / sorting data
+    # 2) addition of date, function name (make a utils in logging_sw)
+    logs = logging_sw.get_started_logger(preprocess_data.logging_path, "preprocess")
+
     if isinstance(pp_steps, str):
         pp_steps_to_run, _, _ = configs.get_configs(pp_steps)
     else:
@@ -62,6 +66,8 @@ def preprocess(
         perform_preprocessing_step(
             step_num, pp_info, preprocess_data, pp_step_names, pp_funcs, verbose
         )
+
+    logs.stop_logging()
 
     return preprocess_data
 

--- a/spikewrap/pipeline/sort.py
+++ b/spikewrap/pipeline/sort.py
@@ -6,6 +6,8 @@ import shutil
 from pathlib import Path
 from typing import TYPE_CHECKING, Dict, Literal, Optional, Tuple, Union
 
+from ..utils import logging_sw
+
 if TYPE_CHECKING:
     from ..data_classes.sorting import SortingData
 
@@ -69,6 +71,8 @@ def run_sorting(
         slurm.run_sorting_slurm(**local_args)
         return sorting_data
 
+    logs = logging_sw.get_started_logger(sorting_data.logging_path, "sorting")
+
     sorter_options_dict = validate_inputs(slurm_batch, sorter, sorter_options, verbose)
 
     # Load preprocessed data from saved preprocess output path.
@@ -101,6 +105,8 @@ def run_sorting(
     )
 
     move_singularity_image_if_required(sorting_data, singularity_image, sorter)
+
+    logs.stop_logging()
 
     return sorting_data
 

--- a/spikewrap/utils/logging_sw.py
+++ b/spikewrap/utils/logging_sw.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+import logging
+import sys
+from datetime import datetime
+from pathlib import Path
+from typing import Literal, Union
+
+
+class HandleLogging:  # TODO: better explain when this is on / off
+    """
+    Handle logging for SpikeWrap. The aim of spike wrap logging is
+    to agnostically log everything printed by stdout and stderr
+    to a log file. Because we do not have control over logging
+    in SpikeInterface, we can re-pipe all stdout and stderr
+    messages to loggers with the appropriate output streams.
+
+    Both stdout and stderr are always piped to a logger that
+    outputs to file (`self.logger_file`). Additionally,
+    stdout is re-piped back to stdout with another logger (`self.logger_stdout`)
+    while stderr is piped back to stderr (`self.logger_stderr`).
+
+    This ensures that all stdout and stderr messages are logged to file
+    without interfering with the normal message printing.
+    """
+
+    def __init__(self):
+        self.bkup_stdout = None
+        self.bkup_stderr = None
+        self.logger_file = None
+        self.logger_stdout = None
+        self.logger_stderr = None
+        self.this_instance_is_logging = False
+
+    def start_logging(self, log_filepath: Union[Path, str]):
+        """
+        Here the three loggers that pipe to file, stdout and
+        stderr are defined. Then, sys.stdout is overridden to
+        pipe to the file logger and the stdout logger. sys.stderr
+        is overridden to pipe to the file logger and the stderr logger.
+
+        stdout and stderr and stored so they can be re-set in
+        `stop_logging()`.
+
+        Parameters
+        ----------
+        log_filepath : Path
+            Path the output logs will be saved to.
+        """
+        if not self.are_already_logging():
+            self.this_instance_is_logging = True
+
+            if not Path(log_filepath).parent.is_dir():
+                Path(log_filepath).parent.mkdir(parents=True, exist_ok=True)
+
+            if isinstance(log_filepath, Path):
+                log_filepath = log_filepath.as_posix()
+
+            # File logger
+            self.logger_file = logging.getLogger("spikewrap_file")
+
+            self.logger_file.addHandler(logging.FileHandler(log_filepath, "a"))
+
+            # Stdout logger
+            self.logger_stdout = logging.getLogger("spikewrap_stdout")
+            stdout_handler = logging.StreamHandler(sys.stdout)
+            self.logger_stdout.addHandler(stdout_handler)
+
+            # Stderr Logger
+            self.logger_stderr = logging.getLogger("spikewrap_stderr")
+            stderr_handler = logging.StreamHandler(sys.stderr)
+            self.logger_stderr.addHandler(stderr_handler)
+
+            # Override system stdout / stderr
+            self.bkup_stdout = sys.stdout
+            self.bkup_stderr = sys.stderr
+
+            sys.stdout = StreamToLogger(  # type: ignore
+                self.logger_file, self.logger_stdout, logging.ERROR
+            )
+            sys.stderr = StreamToLogger(  # type: ignore
+                self.logger_file, self.logger_stderr, logging.ERROR
+            )
+
+    def stop_logging(self):
+        """
+        Stop the existing loggers by removing their stream (i.e. output
+        handlers). Set system stdout and stderr to their original classes
+        so the logger receives no information.
+
+        Note that the removal of the log handlers is critial as this is what is
+        used to check that we are not already logging, which is important
+        to ensure we do not log multiple times when functions call eachother.
+        For example `run_full_pipeline` and `run_sorting` can both log, but
+        we do not want `run_sorting` to start logging if it is called from
+        `run_full_pipeline`.
+        """
+        if self.this_instance_is_logging:
+            for logger in [self.logger_file, self.logger_stdout, self.logger_stderr]:
+                handlers = logger.handlers[:]
+                for handler in handlers:
+                    logger.removeHandler(handler)
+                    handler.close()
+
+            sys.stdout = self.bkup_stdout
+            sys.stderr = self.bkup_stderr
+
+    def are_already_logging(self):
+        """ """
+        loggers = [
+            logging.getLogger("spikewrap_file"),
+            logging.getLogger("spikewrap_stdout"),
+            logging.getLogger("spikewrap_stderr"),
+        ]
+
+        active_loggers = [logger.hasHandlers() for logger in loggers]
+
+        all_on = all(active_loggers)
+        all_off = not any(active_loggers)
+
+        assert (
+            all_on or all_off
+        ), "Some loggers are switched on while others are off. This should not happen."
+
+        if all_on:
+            return True
+        return False
+
+
+class StreamToLogger(object):
+    """
+    Fake file-like stream object that redirects writes to a logger instance.
+    """
+
+    def __init__(self, logger_file, logger_std, level):
+        self.logger_file = logger_file
+        self.logger_std = logger_std
+        self.level = level
+        self.linebuf = ""
+
+    def write(self, buf):
+        for line in buf.rstrip().splitlines():
+            self.logger_file.log(self.level, line.rstrip())
+            self.logger_std.log(self.level, line.rstrip())
+
+    def flush(self):
+        pass
+
+
+def get_started_logger(
+    log_filepath: Path,
+    run_name: Literal["full_pipeline", "preprocess", "sorting", "postprocess"],
+) -> HandleLogging:
+    """
+    Convenience function
+    """
+    format_datetime = datetime.now().strftime("%Y-%m-%d_%H%M%S")
+    log_name = f"{format_datetime}_{run_name}.log"
+
+    logs = HandleLogging()
+    logs.start_logging(log_filepath / log_name)
+    return logs

--- a/spikewrap/utils/utils.py
+++ b/spikewrap/utils/utils.py
@@ -423,3 +423,7 @@ def get_probe_num_groups(data: Union[PreprocessingData, SortingData]) -> int:
     """
     num_groups = np.unique(data[data.init_data_key].get_property("group")).size
     return num_groups
+
+
+def get_logging_path(base_path: Path, sub_name: str):
+    return base_path / "derivatives" / sub_name / "logs"

--- a/spikewrap/utils/utils.py
+++ b/spikewrap/utils/utils.py
@@ -423,7 +423,3 @@ def get_probe_num_groups(data: Union[PreprocessingData, SortingData]) -> int:
     """
     num_groups = np.unique(data[data.init_data_key].get_property("group")).size
     return num_groups
-
-
-def get_logging_path(base_path: Path, sub_name: str):
-    return base_path / "derivatives" / sub_name / "logs"


### PR DESCRIPTION
This PR adds logging, by writing all stdout and stderr to file. It must be done in this way rather than explicitly handling logging messages because we also want to log lower-level function calls that output as print statements or on stderr within SpikeInterface or even sorters that SpikeInterface calls..

This logger is initialised within the main entry methods, `run_full_pipeline`, `run_sorting`, `run_postprocessing` and closed at the end of the function body. Because `run_sorting` and `run-postprocessing` can be called individually but are also called from within `run_full_pipeline`, the logger class will check if we are currently logging, if so, that instantiation will not log anything.

Further, a `load_data` convenience method is introduced so that `PreprocessData` can be initialised before data loading, giving access to its generated paths (including the logging path). This means that we can log the output from the load file attempt but  also provide a convenience load-data API.