### PR TITLE
Tidy up imports, tidy up save / load preprocessing to be clearer.

### DIFF
--- a/spikewrap/examples/example_full_pipeline.py
+++ b/spikewrap/examples/example_full_pipeline.py
@@ -14,7 +14,7 @@ run_names = [
 ]
 
 config_name = "default"
-sorter = "kilosort2_5"  #  "kilosort2_5"  # "spykingcircus" # mountainsort5
+sorter = "mountainsort5"  #  "kilosort2_5"  # "spykingcircus" # mountainsort5
 
 if __name__ == "__main__":
     run_full_pipeline(
@@ -23,7 +23,7 @@ if __name__ == "__main__":
         run_names,
         config_name,
         sorter,
-        existing_preprocessed_data="load_if_exists",
+        existing_preprocessed_data="overwrite",
         existing_sorting_output="overwrite",
         overwrite_postprocessing=True,
         slurm_batch=False,

--- a/spikewrap/examples/example_sort.py
+++ b/spikewrap/examples/example_sort.py
@@ -3,7 +3,8 @@ from pathlib import Path
 from spikewrap.pipeline.sort import run_sorting
 
 base_path = Path(
-    r"/ceph/neuroinformatics/neuroinformatics/scratch/jziminski/ephys/test_data/steve_multi_run/1119617/time-mid"
+    r"C:\data\ephys\test_data\steve_multi_run\1119617\time-short"
+    # r"/ceph/neuroinformatics/neuroinformatics/scratch/jziminski/ephys/test_data/steve_multi_run/1119617/time-mid"
 )
 sub_name = "1119617"
 run_name = "1119617_LSE1_shank12_posttest1_pretest1"
@@ -17,8 +18,8 @@ if __name__ == "__main__":
     # sorting uses multiprocessing so must be in __main__
     run_sorting(
         preprocessed_data_path,
-        sorter="kilosort2_5",
-        sorter_options={"kilosort2_5": {"car": False}},
-        overwrite_existing_sorter_output=False,
+        sorter="mountainsort5",
+        #        sorter_options={"kilosort2_5": {"car": False}},
+        overwrite_existing_sorter_output=True,
         slurm_batch=False,
     )

--- a/spikewrap/pipeline/load_data.py
+++ b/spikewrap/pipeline/load_data.py
@@ -2,15 +2,14 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, List, Union
 
-if TYPE_CHECKING:
-    from pathlib import Path
-
-
 import spikeinterface.extractors as se
 from spikeinterface import append_recordings
 
 from ..data_classes.preprocessing import PreprocessingData
 from ..data_classes.sorting import SortingData
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 def load_spikeglx_data(

--- a/spikewrap/pipeline/visualise.py
+++ b/spikewrap/pipeline/visualise.py
@@ -2,12 +2,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, List, Optional, Tuple, Union
 
-if TYPE_CHECKING:
-    import matplotlib
-    from numpy.typing import NDArray
-    from spikeinterface.core import BaseRecording
-
-
 import matplotlib.pyplot as plt
 import numpy as np
 import spikeinterface.widgets as sw
@@ -15,6 +9,11 @@ import spikeinterface.widgets as sw
 from ..data_classes.preprocessing import PreprocessingData
 from ..data_classes.sorting import SortingData
 from ..utils import utils
+
+if TYPE_CHECKING:
+    import matplotlib
+    from numpy.typing import NDArray
+    from spikeinterface.core import BaseRecording
 
 
 def visualise(

--- a/spikewrap/utils/checks.py
+++ b/spikewrap/utils/checks.py
@@ -81,6 +81,7 @@ def _check_cuda() -> None:
         utils.message_user(
             "NVIDIA GPU drivers not detected. Sorters that require\n"
             "NVIDIA GPU such as Kilosort will not be able to run."
+        )
 
 
 def _check_pip_dependencies() -> None:
@@ -115,7 +116,7 @@ def _check_pip_dependencies() -> None:
         utils.message_user("All python dependencies are installed.")
 
 
-def _system_call_sucess(command: str) -> bool:
+def _system_call_success(command: str) -> bool:
     return (
         subprocess.run(
             command, shell=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL

--- a/spikewrap/utils/utils.py
+++ b/spikewrap/utils/utils.py
@@ -1,22 +1,19 @@
 from __future__ import annotations
 
+import copy
+import os.path
+import subprocess
+from pathlib import Path
 from typing import TYPE_CHECKING, Callable, Dict, List, Literal, Tuple, Union
+
+import numpy as np
+from spikeinterface import concatenate_recordings
 
 if TYPE_CHECKING:
     from spikeinterface.core import BaseRecording
 
     from ..data_classes.preprocessing import PreprocessingData
     from ..data_classes.sorting import SortingData
-
-import copy
-import os.path
-import subprocess
-from pathlib import Path
-
-import numpy as np
-from spikeinterface import concatenate_recordings
-
-# TODO: how does splitting by group work for sorting?
 
 
 def canonical_names(name: str) -> str:
@@ -156,7 +153,9 @@ def concatenate_runs(recording: BaseRecording) -> BaseRecording:
         The SpikeInterface recording object with all
         segments concatenated into a single segments.
     """
-    message_user(f"Concatenating {recording.get_num_segments()} into a single segment.")
+    message_user(
+        f"Concatenating {recording.get_num_segments()} sessions into a single segment."
+    )
 
     concatenated_recording = concatenate_recordings([recording])
 


### PR DESCRIPTION
1) Tidy up imports so that `TYPE_CHECKING` block is last, which makes more easier import sorting.
2) Rework the save preprocessing function in `run_full_pipeline` to be clearer, and make a clear distinction between preprocessing and sorting by having the sorting function take the preprocessing path both the `preprocess_data` object.