### PR TITLE
Refactor to perform processing per-run, introduce `concat_for_sorting` option.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
     "spython",  # I think missing from SI?
     "submitit",
     "PyYAML",
+    "toml",
     # sorter-specific
     "tridesclous",
     "mountainsort5",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
     "toml",
     # sorter-specific
     "tridesclous",
+    # "spyking-circus", TODO: this is not straightforward, requires mpi4py. TBD if we want to manage this.
     "mountainsort5",
     "docker",  # TODO: windows only!
     "cuda-python",

--- a/spikewrap/configs/test_pp_small_file.yaml
+++ b/spikewrap/configs/test_pp_small_file.yaml
@@ -51,8 +51,6 @@
   - remove_artifacts
   - list_triggers:
     - - 1
-    - - 2
-    - - 3
   '15':
   - resample
   - resample_rate: 2

--- a/spikewrap/data_classes/base.py
+++ b/spikewrap/data_classes/base.py
@@ -2,18 +2,30 @@ import fnmatch
 from collections import UserDict
 from collections.abc import ItemsView, KeysView, ValuesView
 from pathlib import Path
-from typing import List, Tuple, Union
+from typing import List, Literal, Optional, Union
 
 from ..utils import utils
 
 
 class BaseUserDict(UserDict):
     """
+    Base class for `PreprocessingData` and `SortingData`
+    used for checking and formatting `base_path`, `sub_name`
+    and `run_names`. The layout of the `rawdata` and
+    `derivatives` folder is identical up to the run
+    folder, allowing use of this class for
+    preprocessing and sorting.
+
     Base UserDict that implements the
     keys(), values() and items() convenience functions.
     """
 
-    def __init__(self, base_path, sub_name, run_names):
+    def __init__(
+        self,
+        base_path: Union[str, Path],
+        sub_name: str,
+        run_names: Union[List[str], str],
+    ) -> None:
         super(BaseUserDict, self).__init__()
 
         self.base_path = Path(base_path)
@@ -23,20 +35,21 @@ class BaseUserDict(UserDict):
             run_names,
         )
 
-    def _top_level_folder(self):
+    def _top_level_folder(self) -> Literal["rawdata", "derivatives"]:
+        """
+        The name of the top level folder, either 'rawdata' for
+        preprocessing (i.e. loaded from rawdata) or `derivatives`
+        for sorting (i.e. loaded from derivatives).
+        """
         raise NotImplementedError
 
-    def validate_inputs(self, run_names: Union[str, list]) -> Tuple[Path, List[str]]:
+    def validate_inputs(self, run_names: Union[str, List[str]]) -> List[str]:
         """
         Check the rawdata / derivatives path, subject path exists
         and ensure run_names is a list of strings.
 
         Parameters
         ----------
-        base_path : Union[str, Path]
-            Path to the base folder in which `rawdata` folder containing
-            all rawdata (i.e. list of subject names) are held.
-
         run_names : List[str]
             List of run names to process, in order they should be
             processed / concatenated.
@@ -88,7 +101,7 @@ class BaseUserDict(UserDict):
 
         return run_names
 
-    def get_run_path(self, run_name):
+    def get_run_path(self, run_name: Optional[str] = None) -> Path:
         return self.get_sub_folder_path() / f"{run_name}"
 
     def get_sub_folder_path(self) -> Path:
@@ -107,7 +120,7 @@ class BaseUserDict(UserDict):
 
     # Preprocessing Paths --------------------------------------------------------------
 
-    def get_preprocessing_path(self, run_name) -> None:
+    def get_preprocessing_path(self, run_name: Optional[str] = None) -> Path:
         """
         Set the folder tree where preprocessing output will be
         saved. This is canonical and should not change.
@@ -119,16 +132,15 @@ class BaseUserDict(UserDict):
             / f"{run_name}"
             / "preprocessed"
         )
-
         return preprocessed_output_path
 
-    def _get_pp_binary_data_path(self, run_name):
+    def _get_pp_binary_data_path(self, run_name: Optional[str] = None) -> Path:
         return self.get_preprocessing_path(run_name) / "si_recording"
 
-    def _get_sync_channel_data_path(self, run_name):
+    def _get_sync_channel_data_path(self, run_name: Optional[str] = None) -> Path:
         return self.get_preprocessing_path(run_name) / "sync_channel"
 
-    def _get_preprocessing_info_path(self, run_name):
+    def _get_preprocessing_info_path(self, run_name: Optional[str] = None) -> Path:
         return self.get_preprocessing_path(run_name) / utils.canonical_names(
             "preprocessed_yaml"
         )

--- a/spikewrap/data_classes/base.py
+++ b/spikewrap/data_classes/base.py
@@ -1,5 +1,10 @@
+import fnmatch
 from collections import UserDict
 from collections.abc import ItemsView, KeysView, ValuesView
+from pathlib import Path
+from typing import List, Tuple, Union
+
+from ..utils import utils
 
 
 class BaseUserDict(UserDict):
@@ -8,8 +13,125 @@ class BaseUserDict(UserDict):
     keys(), values() and items() convenience functions.
     """
 
-    def __init__(self):
+    def __init__(self, base_path, sub_name, run_names):
         super(BaseUserDict, self).__init__()
+
+        self.base_path = Path(base_path)
+        self.sub_name = sub_name
+
+        self.run_names = self.validate_inputs(
+            run_names,
+        )
+
+    def _top_level_folder(self):
+        raise NotImplementedError
+
+    def validate_inputs(self, run_names: Union[str, list]) -> Tuple[Path, List[str]]:
+        """
+        Check the rawdata / derivatives path, subject path exists
+        and ensure run_names is a list of strings.
+
+        Parameters
+        ----------
+        base_path : Union[str, Path]
+            Path to the base folder in which `rawdata` folder containing
+            all rawdata (i.e. list of subject names) are held.
+
+        run_names : List[str]
+            List of run names to process, in order they should be
+            processed / concatenated.
+
+        Returns
+        -------
+        run_names : List[str]
+            Validated `run_names` as a List.
+        """
+        top_level_folder_path = self.base_path / self._top_level_folder()
+
+        assert (top_level_folder_path / self.sub_name).is_dir(), (
+            f"Subject directory not found. {self.sub_name} "
+            f"is not a folder in {top_level_folder_path}"
+        )
+
+        assert top_level_folder_path.is_dir(), (
+            f"Ensure there is a folder in base path called '{self._top_level_folder()}'.\n"
+            f"No {self._top_level_folder()} directory found at {top_level_folder_path}\n"
+            f"where subject-level folders must be placed."
+        )
+
+        if not isinstance(run_names, list):
+            run_names = [run_names]
+
+        for run_name in run_names:
+            gate_str = fnmatch.filter(run_name.split("_"), "g?")
+
+            assert len(gate_str) > 0, (
+                f"The SpikeGLX gate index should be in the run name. "
+                f"It was not found in the name {run_name}."
+                f"\nEnsure the gate number is in the SpikeGLX-output filename."
+            )
+
+            assert len(gate_str) == 1, (
+                f"The SpikeGLX gate appears in the name " f"{run_name} more than once"
+            )
+
+            assert int(gate_str[0][1:]) == 0, (
+                f"Gate with index larger than 0 is not supported. This is found "
+                f"in run name {run_name}. "
+            )
+
+            run_path = self.get_run_path(run_name)
+            assert run_path.is_dir(), (
+                f"The run folder {run_path.stem} cannot be found at "
+                f"file path {run_path.parent}."
+            )
+
+        return run_names
+
+    def get_run_path(self, run_name):
+        return self.get_sub_folder_path() / f"{run_name}"
+
+    def get_sub_folder_path(self) -> Path:
+        """
+        Get the path to the rawdata subject folder.
+
+        Returns
+        -------
+        sub_folder_path : Path
+            Path to the self.sub_name folder in the `rawdata` path folder.
+        """
+        sub_folder_path = Path(
+            self.base_path / self._top_level_folder() / self.sub_name
+        )
+        return sub_folder_path
+
+    # Preprocessing Paths --------------------------------------------------------------
+
+    def get_preprocessing_path(self, run_name) -> None:
+        """
+        Set the folder tree where preprocessing output will be
+        saved. This is canonical and should not change.
+        """
+        preprocessed_output_path = (
+            self.base_path
+            / "derivatives"
+            / self.sub_name
+            / f"{run_name}"
+            / "preprocessed"
+        )
+
+        return preprocessed_output_path
+
+    def _get_pp_binary_data_path(self, run_name):
+        return self.get_preprocessing_path(run_name) / "si_recording"
+
+    def _get_sync_channel_data_path(self, run_name):
+        return self.get_preprocessing_path(run_name) / "sync_channel"
+
+    def _get_preprocessing_info_path(self, run_name):
+        return self.get_preprocessing_path(run_name) / utils.canonical_names(
+            "preprocessed_yaml"
+        )
 
     def keys(self) -> KeysView:
         return self.data.keys()

--- a/spikewrap/data_classes/postprocessing.py
+++ b/spikewrap/data_classes/postprocessing.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import spikeinterface as si
+from spikeinterface import curation
+from spikeinterface.extractors import NpzSortingExtractor
+
+from ..data_classes.sorting import SortingData
+from ..utils import utils
+from .sorting import SortingData
+
+
+class PostprocessingData:
+    """ """
+
+    def __init__(self, sorting_path):
+        self.sorting_path = Path(sorting_path)
+        self.sorter_output_path = self.sorting_path / "sorter_output"
+        self.sorting_info_path = self.sorting_path / utils.canonical_names(
+            "sorting_yaml"
+        )
+
+        self.check_sorting_paths_exist()
+
+        self.sorting_info = utils.load_dict_from_yaml(self.sorting_info_path)
+
+        self.sorting_data = SortingData(
+            self.sorting_info["base_path"],
+            self.sorting_info["sub_name"],
+            self.sorting_info["run_names"],
+            self.sorting_info["sorter"],
+            self.sorting_info["concat_for_sorting"],
+        )
+        self.sorting_data.load_preprocessed_binary()
+
+        self.sorted_run_name = self.sorting_info["sorted_run_name"]
+        self.preprocessing_info = self.sorting_info["preprocessing"]
+
+        self.check_that_preprocessing_data_has_not_changed_since_sorting()
+
+        self.preprocessed_recording = self.sorting_data[self.sorted_run_name]
+        self.sorting_output = self.get_sorting_extractor_object()
+
+    def check_that_preprocessing_data_has_not_changed_since_sorting(self):
+        """ """
+        if self.sorting_data.concat_for_sorting:
+            run_names = self.sorting_data.run_names
+        else:
+            run_names = [self.sorted_run_name]
+
+        for run_name in run_names:
+            preprocessing_info_path = self.sorting_data._get_preprocessing_info_path(
+                run_name
+            )
+            info_currently_in_preprocessing_folder = utils.load_dict_from_yaml(
+                preprocessing_info_path
+            )
+            assert (
+                self.sorting_info["preprocessing"][run_name]
+                == info_currently_in_preprocessing_folder
+            )
+
+    def check_sorting_paths_exist(self):
+        """ """
+        if not self.sorting_path.is_dir():
+            raise FileNotFoundError(
+                f"No folder found at {self.sorting_path}. "
+                f"Postprocessing was not performed."
+            )
+
+        if not self.sorting_path.name == "sorting":
+            extra_message = (
+                f"The 'sorting' folder was found in this folder path. "
+                f"The path to the 'sorting' folder should be passed, "
+                f"i.e: {self.sorting_path / 'sorting'}"
+                if any(self.sorting_path.glob("sorting"))
+                else ""
+            )
+
+            raise FileNotFoundError(
+                f"The path is not to the 'sorting' folder. "
+                f"Output was not found at "
+                f"{self.sorting_path}.\n"
+                f"{extra_message}"
+            )
+
+        if not self.sorter_output_path.is_dir():
+            raise FileNotFoundError(
+                f"There is no 'sorter_output' folder in the 'sorting' output "
+                f"folder at {self.sorter_output_path}. Check that sorting "
+                f"completely successfully."
+            )
+
+        if not self.sorting_info_path.is_file():
+            raise FileNotFoundError(
+                f"{utils.canonical_names('sorting_yaml')} was not found at"
+                f"{self.sorting_info_path}. Please check sorting finished successfully."
+            )
+
+    def get_sorting_extractor_object(self):
+        """"""
+        sorter_output_path = self.sorting_path / "sorter_output"
+
+        sorter = self.sorting_data.sorter
+
+        if "kilosort" in self.sorting_data.sorter:
+            sorting = si.extractors.read_kilosort(
+                folder_path=sorter_output_path,
+                keep_good_only=False,
+            )
+        elif sorter == "mountainsort5":
+            sorting = NpzSortingExtractor(
+                (sorter_output_path / "firings.npz").as_posix()
+            )
+
+        elif sorter == "tridesclous":
+            sorting = si.extractors.read_tridesclous(
+                folder_path=sorter_output_path.as_posix()
+            )
+
+        elif sorter == "spykingcircus":
+            sorting = si.extractors.read_spykingcircus(
+                folder_path=sorter_output_path.as_posix()
+            )
+
+        sorting = sorting.remove_empty_units()
+        sorting_without_excess_spikes = curation.remove_excess_spikes(
+            sorting, self.preprocessed_recording
+        )
+
+        return sorting_without_excess_spikes
+
+    def get_postprocessing_path(self):
+        run_name = (
+            None if self.sorting_data.concat_for_sorting else self.sorted_run_name
+        )
+        return self.sorting_data.get_postprocessing_path(run_name)
+
+    def get_quality_metrics_path(self):
+        return self.get_postprocessing_path() / "quality_metrics.csv"
+
+    def get_unit_locations_path(self):
+        return self.get_postprocessing_path() / "unit_locations.csv"

--- a/spikewrap/data_classes/postprocessing.py
+++ b/spikewrap/data_classes/postprocessing.py
@@ -6,7 +6,6 @@ import spikeinterface as si
 from spikeinterface import curation
 from spikeinterface.extractors import NpzSortingExtractor
 
-from ..data_classes.sorting import SortingData
 from ..utils import utils
 from .sorting import SortingData
 

--- a/spikewrap/data_classes/preprocessing.py
+++ b/spikewrap/data_classes/preprocessing.py
@@ -1,11 +1,8 @@
-import fnmatch
-import os
 import shutil
-import warnings
 from pathlib import Path
-from typing import Dict, List, Optional, Tuple, Union
+from typing import Dict, List, Optional, Union
 
-import yaml
+import spikeinterface
 
 from ..utils import utils
 from .base import BaseUserDict
@@ -44,173 +41,16 @@ class PreprocessingData(BaseUserDict):
             The SpikeGLX run name (i.e. not including the gate index)
             or list of run names.
         """
-        super(PreprocessingData, self).__init__()
-
-        self.top_level_folder = "rawdata"
-        self.init_data_key = "0-raw"
-
-        self.base_path, checked_run_names, self.rawdata_path = self.validate_inputs(
-            base_path,
-            sub_name,
-            run_names,
-        )
-
-        self.sub_name = sub_name
-
-        (
-            self.all_run_paths,
-            self.all_run_names,
-            self.pp_run_name,
-        ) = self.create_runs_from_single_or_multiple_run_names(checked_run_names)
+        super(PreprocessingData, self).__init__(base_path, sub_name, run_names)
 
         self.pp_steps: Optional[Dict] = None
-        self.data: Dict = {"0-raw": None}
-        self.sync = None
-
-        self.logging_path = self.get_logging_path()
-        self.preprocessed_data_path: Path
-        self._pp_data_attributes_path: Path
-        self._pp_binary_data_path: Path
-        self._sync_channel_data_path: Path
-        self._set_preprocessing_output_path()
-
-    # Handle Multiple Runs -------------------------------------------------------------
-
-    def create_runs_from_single_or_multiple_run_names(
-        self,
-        run_names: List[str],
-    ) -> Tuple[List[Path], List[str], str]:
-        """
-        The run_names may be a single run, or a list of runs to process.
-        Return a list of paths to the runs found on the system. enforces
-        that the runs are in datetime order.
-
-        Parameters
-        ----------
-        run_names : Union[List[str], str]
-            The SpikeGLX run name (i.e. not including the gate index) or
-            list of run names.
-
-        Returns
-        -------
-        all_run_paths : List[Path]
-            List of full filepaths for all runs used in the pipeline.
-
-        all_run_names : List[str]
-            List of run names (folder names within the subject level folder)
-            to be used in the pipeline.
-
-        run_name : str
-            The name of the run used in the derivatives. For a single run,
-            this will be the name of the run. When run_names is a list of run
-            names, this will be an amalgamation of all run names
-            (see self.make_run_name_from_multiple_run_names)
-        """
-        if len(run_names) > 1:
-            all_run_paths, run_name = self.get_multi_run_names_paths(run_names)
-        else:
-            run_name = run_names[0]
-            all_run_paths = [self.get_sub_folder_path() / f"{run_name}_g0"]
-
-        assert len(run_names) > 0, (
-            f"No runs found for {run_names}. "
-            f"Make sure to specify run_names without gate / trigger (e.g. no _g0)."
-        )
-
-        all_run_names = [path_.stem for path_ in all_run_paths]
-
-        for run_path in all_run_paths:
-            assert run_path.is_dir(), (
-                f"The run folder {run_path.stem} cannot be found at "
-                f"file path {run_path.parent}"
-            )
-
-        utils.message_user(f"The order of the loaded runs is:" f"{all_run_names}")
-
-        return all_run_paths, all_run_names, run_name
-
-    def get_multi_run_names_paths(
-        self,
-        run_names: List[str],
-    ) -> Tuple[List[Path], str]:
-        """
-        Get the paths to the runs when there is more than one run specified.
-        If it is a list of run names, they are searched, checked exist and
-        assert in datetime order.
-
-        Parameters
-        ----------
-        run_names : Union[List[str], str]
-            The spikeglx run name (i.e. not including the gate index) or
-            list of run names.
-
-        Returns
-        -------
-        all_run_paths : List[Path]
-            List of full filepaths for all runs used in the pipeline.
-
-        all_run_names : List[str]
-            List of run names (folder names within the subject level folder)
-            to be used in the pipeline.
-
-        run_name : str
-            The name of the run used in the derivatives. For a single run,
-            this will be the name of the run. When run_names is a list of run names,
-            this will be an amalgamation of all run names
-            (see self.make_run_name_from_multiple_run_names)
-        """
-        all_run_paths = [
-            self.get_sub_folder_path() / f"{name}_g0" for name in run_names
-        ]
-
-        if not utils.list_of_files_are_in_datetime_order(all_run_paths, "creation"):
-            warnings.warn(
-                "The runs provided are not in creation datetime order.\n"
-                "They will be concatenated in the order provided."
-            )
-
-        pp_run_name = self.make_run_name_from_multiple_run_names(run_names)
-
-        return all_run_paths, pp_run_name
-
-    def make_run_name_from_multiple_run_names(self, run_names: List[str]) -> str:
-        """
-        Make a single run_name given a list of run names. This will use the
-        first part of the first name and then add unique parts of the
-        subsequent names to the string.
-
-        Parameters
-        ----------
-        run_names : Union[List[str], str]
-            A list of run names.
-
-        Returns
-        -------
-        pp_run_name : str
-            A single run name formed from the list of run names.
-        """
-        all_names = []
-        for idx, name in enumerate(run_names):
-            if idx == 0:
-                all_names.extend(name.split("_"))
-            else:
-                split_name = name.split("_")
-                new_name = [n for n in split_name if n not in all_names]
-                all_names.extend(new_name)
-
-        if "g0" in all_names:
-            all_names.remove("g0")
-
-        pp_run_name = "_".join(all_names)
-
-        return pp_run_name
-
-    def get_expected_sorter_path(self, sorter: str) -> Path:
-        return utils.make_sorter_base_output_path(
-            self.base_path, self.sub_name, self.pp_run_name, sorter
-        )
+        self.data: Dict = {run_name: {"0-raw": None} for run_name in self.run_names}
+        self.sync = {run_name: None for run_name in self.run_names}
 
     # Load and Save --------------------------------------------------------------------
+
+    def _top_level_folder(self):
+        return "rawdata"
 
     def set_pp_steps(self, pp_steps: Dict) -> None:
         """
@@ -225,7 +65,7 @@ class PreprocessingData(BaseUserDict):
         """
         self.pp_steps = pp_steps
 
-    def save_all_preprocessed_data(self, overwrite: bool = False) -> None:
+    def save_preprocessed_data(self, run_name: str, overwrite: bool = False) -> None:
         """
         Save the preprocessed output data to binary, as well
         as important class attributes to a .yaml file.
@@ -241,155 +81,48 @@ class PreprocessingData(BaseUserDict):
             (`si_recording`) already exists where it is trying to write one.
             In this case, an error  should be raised before this function
             is called.
+
         """
         if overwrite:
-            if self.preprocessed_data_path.is_dir():
-                shutil.rmtree(self.preprocessed_data_path)
-        self._save_data_class()
-        self._save_preprocessed_binary()
-        self._save_sync_channel()
+            if self.get_preprocessing_path(run_name).is_dir():
+                shutil.rmtree(self.get_preprocessing_path(run_name))
 
-    def _save_preprocessed_binary(self) -> None:
+        self._save_preprocessed_binary(run_name)
+        self._save_sync_channel(run_name)
+        self._save_preprocessing_info(run_name)
+
+    def _save_preprocessed_binary(self, run_name: str) -> None:
         """
         Save the fully preprocessed data (i.e. last step in the
         preprocessing chain) to binary file. This is required for sorting.
         """
-        recording, __ = utils.get_dict_value_from_step_num(self, "last")
-        recording.save(folder=self._pp_binary_data_path, chunk_memory="10M")
+        recording, __ = utils.get_dict_value_from_step_num(self[run_name], "last")
+        recording.save(
+            folder=self._get_pp_binary_data_path(run_name), chunk_memory="10M"
+        )
 
-    def _save_sync_channel(self) -> None:
+    def _save_sync_channel(self, run_name: str) -> None:
         """ """
         assert self.sync is not None, "Sync channel on PreprocessData is None"
-        self.sync.save(folder=self._sync_channel_data_path, chunk_memory="10M")
+        self.sync[run_name].save(
+            folder=self._get_sync_channel_data_path(run_name), chunk_memory="10M"
+        )
 
-    def _save_data_class(self) -> None:
-        """
-        Save the key attributes of this class to a .yaml file.
-        """
+    def _save_preprocessing_info(self, run_name: str) -> None:
+        """ """
         assert self.pp_steps is not None, "type narrow `pp_steps`."
 
         utils.cast_pp_steps_values(self.pp_steps, "list")
 
-        attributes_to_save = {
+        preprocessing_info = {
             "base_path": self.base_path.as_posix(),
             "sub_name": self.sub_name,
-            "pp_run_name": self.pp_run_name,
+            "rawdata_path": self.get_run_path(run_name).as_posix(),
             "pp_steps": self.pp_steps,
-            "all_run_paths": [path_.as_posix() for path_ in self.all_run_paths],
-            "all_run_names": [name for name in self.all_run_names],
-            "preprocessed_data_path": self.preprocessed_data_path.as_posix(),
-            "_pp_binary_data_path": self._pp_binary_data_path.as_posix(),
-            "_pp_data_attributes_path": self._pp_data_attributes_path.as_posix(),
-            "_sync_channel_data_path": self._sync_channel_data_path.as_posix(),
+            "si_version": spikeinterface.__version__,
+            "datetime_written": utils.get_formatted_datetime(),
         }
-        if not self.preprocessed_data_path.is_dir():
-            os.makedirs(self.preprocessed_data_path)
 
-        with open(
-            self._pp_data_attributes_path,
-            "w",
-        ) as attributes:
-            yaml.dump(attributes_to_save, attributes, sort_keys=False)
-
-    # Handle Paths ---------------------------------------------------------------------
-
-    def _set_preprocessing_output_path(self) -> None:
-        """
-        Set the folder tree where preprocessing output will be
-        saved. This is canonical and should not change.
-
-        TODO: move this to a canonical_filepaths module.
-        """
-        self.preprocessed_data_path = (
-            self.base_path
-            / "derivatives"
-            / self.sub_name
-            / f"{self.pp_run_name}"
-            / "preprocessed"
-        )
-
-        self._pp_data_attributes_path = (
-            self.preprocessed_data_path / utils.canonical_names("preprocessed_yaml")
-        )
-        self._pp_binary_data_path = self.preprocessed_data_path / "si_recording"
-        self._sync_channel_data_path = self.preprocessed_data_path / "sync_channel"
-
-    def get_sub_folder_path(self) -> Path:
-        """
-        Get the path to the rawdata subject folder.
-
-        Returns
-        -------
-        sub_folder_path : Path
-            Path to the self.sub_name folder in the `rawdata` path folder.
-        """
-        sub_folder_path = Path(self.base_path / self.top_level_folder / self.sub_name)
-        return sub_folder_path
-
-    # Validate Inputs ------------------------------------------------------------------
-
-    def validate_inputs(
-        self, base_path: Union[str, Path], sub_name: str, run_names: Union[str, list]
-    ) -> Tuple[Path, List[str], Path]:
-        """
-        Check the rawdata path, subject path exists and ensure run_names
-        is a list of strings without SpikeGLX gate number of the run names.
-
-        Parameters
-        ----------
-        base_path : Union[str, Path]
-            Path to the base folder in which `rawdata` folder containing
-            all rawdata (i.e. list of subject names) are held.
-
-        sub_name : str
-            'subject' name to preprocess data for.
-
-        run_names : List[str]
-            List of run names to process, in order they should be
-            processed / concatenated.
-
-        Returns
-        -------
-        base_path : Path
-            `base_path` definitely as a Path object.
-
-        run_names : List[str]
-            Validated `run_names` as a List.
-
-        rawdata_path : Path
-            Path to the canonical `rawdata` path required for
-            future processing.
-        """
-        base_path = Path(base_path)
-        rawdata_path = base_path / self.top_level_folder
-
-        assert (rawdata_path / sub_name).is_dir(), (
-            f"Subject directory not found. {sub_name} "
-            f"is not a folder in {rawdata_path}"
-        )
-
-        assert rawdata_path.is_dir(), (
-            f"Ensure there is a folder in base path called 'rawdata'.\n"
-            f"No rawdata directory found at {rawdata_path}\n"
-            f"where subject-level folders are placed."
-        )
-        if not isinstance(run_names, list):
-            run_names = [run_names]
-
-        for name in run_names:
-            assert "g0" not in name.split("_"), (
-                f"gate index should not be on the run name. Remove _g0 from\n" f"{name}"
-            )
-
-        for name in run_names:
-            gate_idx_in_name = fnmatch.filter(name.split("_"), "g?")
-            assert len(gate_idx_in_name) == 0, (
-                f"Gate with index larger than 0 is not supported. This is found "
-                f"in run name {name}. "
-            )
-        return base_path, run_names, rawdata_path
-
-    def get_logging_path(self):
-        return (
-            self.base_path / "derivatives" / self.sub_name / self.pp_run_name / "logs"
+        utils.dump_dict_to_yaml(
+            self._get_preprocessing_info_path(run_name), preprocessing_info
         )

--- a/spikewrap/data_classes/sorting.py
+++ b/spikewrap/data_classes/sorting.py
@@ -1,9 +1,11 @@
+import copy
+import os
 import warnings
 from pathlib import Path
-from typing import Dict, Union
+from typing import Callable, Dict, List, Optional, Tuple
 
 import spikeinterface as si
-import yaml
+from spikeinterface import concatenate_recordings
 
 from ..utils import utils
 from .base import BaseUserDict
@@ -35,136 +37,269 @@ class SortingData(BaseUserDict):
     pattern and can be improved on refactoring of `visualise.py`.
     """
 
-    def __init__(self, preprocessed_data_path: Union[str, Path]):
+    def __init__(
+        self, base_path, sub_name, run_names, sorter: str, concat_for_sorting: bool
+    ):
+        super(SortingData, self).__init__(base_path, sub_name, run_names)
+
+        self.concat_for_sorting = concat_for_sorting
+        self.sorter = sorter
+
+        self._check_preprocessing_exists()
+
+        self.data: Dict = {}
+        self.preprocessing_info_paths = {}
+        self._load_preprocessed_binary()
+
+    def _top_level_folder(self):
+        return "derivatives"
+
+    def _check_preprocessing_exists(self):
         """ """
-        super(SortingData, self).__init__()
 
-        self.preprocessed_data_path = Path(preprocessed_data_path)
-        self.check_preprocessed_data_path_exists()
-
-        self.top_level_folder = "derivatives"
-        self.init_data_key = "0-preprocessed"
-        self.pp_info = self.load_preprocess_data_attributes()
-
-        self.base_path = Path(self.pp_info["base_path"])
-        self.show_warning_if_base_path_diverged()
-
-        self.sub_name = self.pp_info["sub_name"]
-        self.pp_run_name = self.pp_info["pp_run_name"]
-
-        # TODO: duplication from processing(). Figure out inheritance
-        self.logging_path = self.get_logging_path()
-
-        # These paths are set when the sorter
-        # is known, set_sorter_output_paths()
-        self.sorter_base_output_path: Path
-        self.sorter_run_output_path: Path
-        self.postprocessing_output_path: Path
-        self.quality_metrics_path: Path
-        self.unit_locations_path: Path
-
-        # This is set later, depending on
-        # concatenated or not.
-        self.data: Dict = {"0-preprocessed": None}
-
-    def show_warning_if_base_path_diverged(self):
-        """
-        It is expected that the passed preprocessed data output path
-        is in the same location as the data was saved during preprocessed,
-        as stored in the PreprocessData attribute. This can be broken
-        however, in the case of accessing the same folder as a mounted drive.
-        """
-        pp_base_path = [
-            path
-            for path in self.preprocessed_data_path.parents
-            if path.stem == "derivatives"
-        ][0]
-        if pp_base_path != self.base_path:
-            warnings.warn(
-                f"The base path of the `preprocessed_data_path` does not match the "
-                f"`base_path` contained used to run the preprocessing. This is expected "
-                f"if running the same folder from a different location (e.g. mounted drive). "
-                f"Otherwise, check the base paths are correct.\n"
-                f"passed base path: {self.preprocessed_data_path}\n"
-                f"original base path: {self.base_path}"
+        def error_message(path_):
+            return (
+                f"The run folder {path_.stem} cannot be found at "
+                f"file path {path_.parent}."
             )
 
-    def check_preprocessed_data_path_exists(self) -> None:
-        """
-        Ensure the preprocessed data path exists, otherwise
-        it cannot be loaded and sorting will fail.
-        """
-        if not self.preprocessed_data_path.is_dir():
-            raise FileNotFoundError(
-                f"No preprocessed data found at " f"{self.preprocessed_data_path}"
-            )
+        for run_name in self.run_names:
+            assert (
+                prepro_path := self.get_run_path(run_name) / "preprocessed"
+            ).is_dir(), error_message(prepro_path)
 
-    def load_preprocess_data_attributes(self) -> Dict:
-        """
-        Load the PreprocessingData attributes that were
-        saved when writing the preprocessed data to file.
+            assert (
+                recording_path := prepro_path / "si_recording"
+            ).is_dir(), error_message(recording_path)
 
-        These fields are used to set the sorting and other
-        output paths, and for provenance.
-        """
-        with open(
-            Path(self.preprocessed_data_path)
-            / utils.canonical_names("preprocessed_yaml")
-        ) as file:
-            pp_info = yaml.full_load(file)
-        return pp_info
-
-    def load_preprocessed_binary(self, concatenate: bool = True):
+    def _load_preprocessed_binary(self):
         """
         Use SpikeInterface to load the binary-data into a recording object.
+        """
+        # Load the preprocessing recordings
+        recordings = {}
+        for run_name in self.run_names:
+            recordings[run_name] = si.load_extractor(
+                self._get_pp_binary_data_path(run_name)
+            )
+
+        # Set the dict data to the separate or concatenated recordings
+        if not self.concat_for_sorting:
+            self.data = recordings
+        else:
+            concatenated_recording = self._concatenate_si_recording(recordings)
+            self.data = {self.concat_run_name(): concatenated_recording}
+
+    def _concatenate_si_recording(self, recordings):
+        """ """
+        loaded_prepro_run_names, recordings_list = zip(*recordings.items())
+
+        concatenated_recording = concatenate_recordings(recordings_list)
+
+        # Perform some checks before returning.
+        assert loaded_prepro_run_names == tuple(
+            self.run_names
+        ), "Something has gone wrong in the `run_names` ordering."
+
+        if not self._run_names_are_in_datetime_order("creation"):
+            warnings.warn(
+                "The runs provided are not in creation datetime order.\n"
+                "They will be concatenated in the order provided."
+            )
+
+        utils.message_user(
+            f"Concatenating runs in the order: " f"{loaded_prepro_run_names}"
+        )
+
+        return concatenated_recording
+
+    def _run_names_are_in_datetime_order(
+        self, creation_or_modification: str = "creation"
+    ) -> bool:
+        """
+        Assert whether a list of paths are in order. By default, check they are
+        in order by creation date. Can also check if they are ordered by
+        modification date.
 
         Parameters
         ----------
-        concatenate : bool
-            If `True`, all segments in the loaded SpikeInterface
-            recording object will be concatenated into a single
-            segment.
-        """
-        binary_path = self.preprocessed_data_path / "si_recording"  # TODO: configs
+        creation_or_modification : str
+            If "creation", check the list of paths are ordered by creation datetime.
+            Otherwise if "modification", check they are sorterd by modification
+            datetime.
 
-        if not binary_path.is_dir():
-            raise FileNotFoundError(
-                f"No preprocessed SI binary-containing folder "
-                f"found at {binary_path}."
+        Returns
+        -------
+        is_in_time_order : bool
+            Indicates whether `list_of_paths` was in creation or modification time
+            order.
+            depending on the value of `creation_or_modification`.
+        """
+        assert creation_or_modification in [
+            "creation",
+            "modification",
+        ], "creation_or_modification must be 'creation' or 'modification."
+
+        filter: Callable
+        filter = (
+            os.path.getctime
+            if creation_or_modification == "creation"
+            else os.path.getmtime
+        )
+
+        list_of_paths = [self.get_run_path(run_name) for run_name in self.run_names]
+
+        list_of_paths_by_time = copy.deepcopy(list_of_paths)
+        list_of_paths_by_time.sort(key=filter)
+
+        is_in_time_order = list_of_paths == list_of_paths_by_time
+
+        return is_in_time_order
+
+    def save_sorting_info(self, run_name: Optional[str] = None):
+        """"""
+        # Load preprocessing_info for provenance
+        if run_name is None:
+            assert self.concat_for_sorting is True
+            run_names_to_load = self.run_names
+        else:
+            assert self.concat_for_sorting is False
+            run_names_to_load = [run_name]
+
+        preprocessing_info = {"preprocessing": {}}
+
+        for load_prepro_run_name in run_names_to_load:  # TODO: naming!
+            preprocessing_info["preprocessing"][
+                load_prepro_run_name
+            ] = utils.load_dict_from_yaml(
+                self._get_preprocessing_info_path(load_prepro_run_name)
             )
-        recording = si.load_extractor(binary_path)
 
-        if concatenate:
-            recording = utils.concatenate_runs(recording)
+        sorted_run_name = (
+            self.concat_run_name() if self.concat_for_sorting else run_name
+        )
 
-        self.data["0-preprocessed"] = recording
+        preprocessing_info["base_path"] = self.base_path.as_posix()
+        preprocessing_info["sub_name"] = self.sub_name
+        preprocessing_info["run_names"] = self.run_names
+        preprocessing_info["concat_for_sorting"] = self.concat_for_sorting
+        preprocessing_info["sorter"] = self.sorter
+        preprocessing_info["sorted_run_name"] = sorted_run_name
 
-    def set_sorter_output_paths(self, sorter: str) -> None:
+        output_path = self.get_sorting_path(run_name) / utils.canonical_names(
+            "sorting_yaml"
+        )
+
+        utils.dump_dict_to_yaml(output_path, preprocessing_info)
+
+    def get_preprocessed_recording(self, run_name: Optional[str] = None):
+        """"""
+        breakpoint()
+        if self.concat_for_sorting:
+            assert run_name is None
+            recording = self[self.concat_run_name()]
+        else:
+            assert isinstance(run_name, str)
+            recording = self[run_name]
+
+        return recording
+
+    def get_all_run_names(self):
+        if self.concat_for_sorting:
+            run_names = [None]
+        else:
+            run_names = self.run_names
+        return run_names
+
+    # Paths ----------------------------------------------------------------------------
+
+    def _get_base_sorting_path(self, run_name: Optional[str] = None) -> None:
+        """ """
+        sub_folder = self.base_path / "derivatives" / self.sub_name
+        if self.concat_for_sorting:
+            assert run_name is None
+            base_sorting_path = (
+                sub_folder
+                / f"{self.sub_name}-sorting-concat"
+                / self.concat_run_name()
+                / self.sorter
+            )
+        else:
+            assert run_name is not None
+            base_sorting_path = sub_folder / run_name / self.sorter
+
+        return base_sorting_path
+
+    def get_sorting_path(self, run_name: Optional[str] = None):
+        return self._get_base_sorting_path(run_name) / "sorting"
+
+    def get_sorter_output_path(self, run_name: Optional[str] = None):
+        return self.get_sorting_path(run_name) / "sorter_output"
+
+    def get_postprocessing_path(self, run_name: Optional[str] = None):
+        return self._get_base_sorting_path(run_name) / "postprocessing"
+
+    # Handle Multiple Runs -------------------------------------------------------------
+
+    def concat_run_name(
+        self,
+    ) -> Tuple[List[Path], List[str], str]:
         """
-        Set the sorter-specific output paths. The same data may be
-        sorted multiple times by different sorters.
+        The run_names may be a single run, or a list of runs to process.
+        Return a list of paths to the runs found on the system. enforces
+        that the runs are in datetime order.
 
-        sort_base_output_path : str
-            canonical name, is where spikeinterface
-            automatically saves sorter output
+        Returns
+        -------
+        run_names : List[str]
+            List of run names (folder names within the subject level folder)
+            to be used in the pipeline.
+
+        concat_run_name : str
+            A name consisting of the ordered combination of all run names
+            (see self.make_run_name_from_multiple_run_names)
         """
-        self.sorter_base_output_path = utils.make_sorter_base_output_path(
-            self.base_path, self.sub_name, self.pp_run_name, sorter
+        assert len(self.run_names) > 1, (
+            f"Concatenate for sorting (`concat_for_sorting`) is "
+            f"true but only a single run"
+            f"has been passed: {self.run_names}."
         )
 
-        self.sorting_output_path = self.sorter_base_output_path / "sorting"
-        self.sorter_run_output_path = self.sorting_output_path / "sorter_output"
-        self.postprocessing_output_path = (
-            self.sorter_base_output_path / "postprocessing"
-        )
-        self.quality_metrics_path = (
-            self.postprocessing_output_path / "quality_metrics.csv"
-        )
-        self.unit_locations_path = (
-            self.postprocessing_output_path / "unit_locations.csv"
-        )
+        concat_run_name = self._make_run_name_from_multiple_run_names(self.run_names)
 
-    def get_logging_path(self):
-        return (
-            self.base_path / "derivatives" / self.sub_name / self.pp_run_name / "logs"
-        )
+        return concat_run_name
+
+    # Multiple run path naming ---------------------------------------------------------
+
+    @staticmethod
+    def _make_run_name_from_multiple_run_names(run_names: List[str]) -> str:
+        """
+        Make a single run_name given a list of run names. This will use the
+        first part of the first name and then add unique parts of the
+        subsequent names to the string.
+
+        Parameters
+        ----------
+        run_names : Union[List[str], str]
+            A list of run names.
+
+        Returns
+        -------
+        pp_run_name : str
+            A single run name formed from the list of run names.
+        """
+        all_names = []
+        for idx, name in enumerate(run_names):
+            if idx == 0:
+                all_names.extend(name.split("_"))
+            else:
+                split_name = name.split("_")
+                new_name = [n for n in split_name if n not in all_names]
+                all_names.extend(new_name)
+
+        if "g0" in all_names:
+            all_names.remove("g0")
+
+        concat_run_name = "_".join(all_names)
+
+        return concat_run_name

--- a/spikewrap/data_classes/sorting.py
+++ b/spikewrap/data_classes/sorting.py
@@ -1,10 +1,11 @@
+from __future__ import annotations
+
 import copy
 import os
 import warnings
 from typing import TYPE_CHECKING, Callable, Dict, List, Optional, Union
 
 import spikeinterface as si
-from si import BaseRecording
 from spikeinterface import concatenate_recordings
 
 from ..utils import utils
@@ -65,7 +66,7 @@ class SortingData(BaseUserDict):
 
         self.data: Dict = {}
         self.preprocessing_info_paths: Dict = {}
-        self._load_preprocessed_binary()
+        self.load_preprocessed_binary()
 
     def _top_level_folder(self):
         return "derivatives"
@@ -140,7 +141,7 @@ class SortingData(BaseUserDict):
     # Load and concatenate preprocessed data
     # ----------------------------------------------------------------------------------
 
-    def _load_preprocessed_binary(self) -> None:
+    def load_preprocessed_binary(self) -> None:
         """
         Use SpikeInterface to load the binary-data into a recording object.
         see class docstring for details.
@@ -159,7 +160,7 @@ class SortingData(BaseUserDict):
             concatenated_recording = self._concatenate_si_recording(recordings)
             self.data = {self.concat_run_name(): concatenated_recording}
 
-    def _concatenate_si_recording(self, recordings: Dict) -> BaseRecording:
+    def _concatenate_si_recording(self, recordings: Dict) -> si.BaseRecording:
         """
         Concatenate the Spikeinterface recording objects together.
 
@@ -171,7 +172,7 @@ class SortingData(BaseUserDict):
 
         Returns
         -------
-        concatenated_recording : BaseRecording
+        concatenated_recording : si.BaseRecording
             A SI recording object holding the concatenated preprocessed data.
         """
         loaded_prepro_run_names, recordings_list = zip(*recordings.items())
@@ -266,6 +267,15 @@ class SortingData(BaseUserDict):
 
         return concat_run_name
 
+    def get_output_run_name(self, run_name: Optional[str]) -> str:
+        """
+        """
+        if run_name is None:
+            assert self.concat_for_sorting is True
+            return self.concat_run_name()
+        else:
+            return run_name
+
     @staticmethod
     def _make_run_name_from_multiple_run_names(run_names: List[str]) -> str:
         """
@@ -357,7 +367,7 @@ class SortingData(BaseUserDict):
 
     def get_preprocessed_recording(
         self, run_name: Optional[str] = None
-    ) -> BaseRecording:
+    ) -> si.BaseRecording:
         """
         Get the preprocessed recording, that is stored in a dict in which
         keys are the run names (not concentrated) or the amalgamated run name

--- a/spikewrap/data_classes/sorting.py
+++ b/spikewrap/data_classes/sorting.py
@@ -268,8 +268,7 @@ class SortingData(BaseUserDict):
         return concat_run_name
 
     def get_output_run_name(self, run_name: Optional[str]) -> str:
-        """
-        """
+        """ """
         if run_name is None:
             assert self.concat_for_sorting is True
             return self.concat_run_name()

--- a/spikewrap/examples/example_full_pipeline.py
+++ b/spikewrap/examples/example_full_pipeline.py
@@ -8,9 +8,9 @@ base_path = Path(
 )
 sub_name = "1119617"
 run_names = [
-    "1119617_LSE1_shank12",
-    "1119617_posttest1_shank12",
-    "1119617_pretest1_shank12",
+    "1119617_LSE1_shank12_g0",
+    #  "1119617_posttest1_shank12_g0",
+    #  "1119617_pretest1_shank12_g0",
 ]
 
 config_name = "default"
@@ -23,8 +23,14 @@ if __name__ == "__main__":
         run_names,
         config_name,
         sorter,
+        concat_for_sorting=False,
         existing_preprocessed_data="load_if_exists",
         existing_sorting_output="overwrite",
         overwrite_postprocessing=True,
+        delete_intermediate_files=(
+            "recording.dat",
+            "temp_wh.dat",
+            "waveforms",
+        ),
         slurm_batch=False,
     )

--- a/spikewrap/examples/example_full_pipeline.py
+++ b/spikewrap/examples/example_full_pipeline.py
@@ -1,22 +1,21 @@
-# type: ignore
 from pathlib import Path
 
 from spikewrap.pipeline.full_pipeline import run_full_pipeline
 
 base_path = Path(
-    r"C:\data\ephys\test_data\steve_multi_run\1119617\time-short"
-    # "/ceph/neuroinformatics/neuroinformatics/scratch/jziminski/ephys/test_data/steve_multi_run/1119617/time-short"
+    # r"C:\data\ephys\test_data\steve_multi_run\1119617\time-short"
+    "/ceph/neuroinformatics/neuroinformatics/scratch/jziminski/ephys/test_data/steve_multi_run/1119617/time-short"
 )
 
 sub_name = "1119617"
 run_names = [
     "1119617_LSE1_shank12_g0",
-    #  "1119617_posttest1_shank12_g0",
-    #  "1119617_pretest1_shank12_g0",
+    "1119617_posttest1_shank12_g0",
+    "1119617_pretest1_shank12_g0",
 ]
 
 config_name = "default"
-sorter = "mountainsort5"  #  "kilosort2_5"  # "spykingcircus" # mountainsort5
+sorter = "kilosort2_5"  #  "kilosort2_5"  # "spykingcircus" # mountainsort5
 
 if __name__ == "__main__":
     run_full_pipeline(
@@ -25,9 +24,9 @@ if __name__ == "__main__":
         run_names,
         config_name,
         sorter,
-        concat_for_sorting=False,
+        concat_for_sorting=True,
         existing_preprocessed_data="load_if_exists",
-        existing_sorting_output="overwrite",
+        existing_sorting_output="load_if_exists",
         overwrite_postprocessing=True,
         delete_intermediate_files=(
             "recording.dat",

--- a/spikewrap/examples/example_full_pipeline.py
+++ b/spikewrap/examples/example_full_pipeline.py
@@ -1,3 +1,4 @@
+# type: ignore
 from pathlib import Path
 
 from spikewrap.pipeline.full_pipeline import run_full_pipeline
@@ -6,6 +7,7 @@ base_path = Path(
     r"C:\data\ephys\test_data\steve_multi_run\1119617\time-short"
     # "/ceph/neuroinformatics/neuroinformatics/scratch/jziminski/ephys/test_data/steve_multi_run/1119617/time-short"
 )
+
 sub_name = "1119617"
 run_names = [
     "1119617_LSE1_shank12_g0",

--- a/spikewrap/examples/example_postprocess.py
+++ b/spikewrap/examples/example_postprocess.py
@@ -5,17 +5,15 @@ from spikewrap.pipeline.postprocess import run_postprocess
 base_path = Path(
     r"/ceph/neuroinformatics/neuroinformatics/scratch/jziminski/ephys/test_data/steve_multi_run/1119617/time-short"
 )
-# TODO: why is this taking the preprocessed path? isn't sorting more intuitive? or top level? think...
 sub_name = "1119617"
 run_name = "1119617_LSE1_shank12_posttest1_pretest1"
 
-preprocessing_path = (
-    base_path / "derivatives" / sub_name / f"{run_name}" / "preprocessed"
+sorting_path = (
+    base_path / "derivatives" / sub_name / f"{run_name}" / "mountainsort5" / "sorting"
 )
 
 run_postprocess(
-    preprocessing_path,
-    sorter="kilosort2_5",
+    sorting_path,
     existing_waveform_data="overwrite",
     postprocessing_to_run="all",
 )

--- a/spikewrap/examples/example_postprocess.py
+++ b/spikewrap/examples/example_postprocess.py
@@ -9,7 +9,7 @@ sub_name = "1119617"
 run_name = "1119617_LSE1_shank12_posttest1_pretest1"
 
 sorting_path = (
-    base_path / "derivatives" / sub_name / f"{run_name}" / "mountainsort5" / "sorting"
+    base_path / "derivatives" / sub_name / "1119617-sorting-concat" / f"{run_name}" / "mountainsort5" / "sorting"
 )
 
 run_postprocess(

--- a/spikewrap/examples/example_postprocess.py
+++ b/spikewrap/examples/example_postprocess.py
@@ -9,7 +9,13 @@ sub_name = "1119617"
 run_name = "1119617_LSE1_shank12_posttest1_pretest1"
 
 sorting_path = (
-    base_path / "derivatives" / sub_name / "1119617-sorting-concat" / f"{run_name}" / "mountainsort5" / "sorting"
+    base_path
+    / "derivatives"
+    / sub_name
+    / "1119617-sorting-concat"
+    / f"{run_name}"
+    / "mountainsort5"
+    / "sorting"
 )
 
 run_postprocess(

--- a/spikewrap/examples/example_sort.py
+++ b/spikewrap/examples/example_sort.py
@@ -3,11 +3,15 @@ from pathlib import Path
 from spikewrap.pipeline.sort import run_sorting
 
 base_path = Path(
-    r"C:\data\ephys\test_data\steve_multi_run\1119617\time-short"
-    # r"/ceph/neuroinformatics/neuroinformatics/scratch/jziminski/ephys/test_data/steve_multi_run/1119617/time-mid"
+    # r"C:\data\ephys\test_data\steve_multi_run\1119617\time-short"
+    r"/ceph/neuroinformatics/neuroinformatics/scratch/jziminski/ephys/test_data/steve_multi_run/1119617/time-short"
 )
 sub_name = "1119617"
-run_names = "1119617_LSE1_shank12_posttest1_pretest1"
+run_names = [
+    "1119617_LSE1_shank12_g0",
+    "1119617_posttest1_shank12_g0",
+    "1119617_pretest1_shank12_g0",
+]
 
 
 if __name__ == "__main__":

--- a/spikewrap/examples/example_sort.py
+++ b/spikewrap/examples/example_sort.py
@@ -19,6 +19,7 @@ if __name__ == "__main__":
     run_sorting(
         preprocessed_data_path,
         sorter="mountainsort5",
+        concat_for_sorting=True,
         #        sorter_options={"kilosort2_5": {"car": False}},
         overwrite_existing_sorter_output=True,
         slurm_batch=False,

--- a/spikewrap/examples/example_sort.py
+++ b/spikewrap/examples/example_sort.py
@@ -7,20 +7,18 @@ base_path = Path(
     # r"/ceph/neuroinformatics/neuroinformatics/scratch/jziminski/ephys/test_data/steve_multi_run/1119617/time-mid"
 )
 sub_name = "1119617"
-run_name = "1119617_LSE1_shank12_posttest1_pretest1"
-
-preprocessed_data_path = (
-    base_path / "derivatives" / sub_name / f"{run_name}" / "preprocessed"
-)
+run_names = "1119617_LSE1_shank12_posttest1_pretest1"
 
 
 if __name__ == "__main__":
     # sorting uses multiprocessing so must be in __main__
     run_sorting(
-        preprocessed_data_path,
+        base_path,
+        sub_name,
+        run_names,
         sorter="mountainsort5",
         concat_for_sorting=True,
         #        sorter_options={"kilosort2_5": {"car": False}},
-        overwrite_existing_sorter_output=True,
+        existing_sorting_output="fail_if_exists",
         slurm_batch=False,
     )

--- a/spikewrap/examples/example_visualise.py
+++ b/spikewrap/examples/example_visualise.py
@@ -8,7 +8,10 @@ run_names = "1119617_LSE1_shank12"
 
 data = load_data.load_data(base_path, sub_name, run_names, "spikeglx")
 
-preprocess_data = preprocess(data, pp_steps="default")
+for run_name in run_names:
+    preprocess_data = preprocess(
+        data, run_name, pp_steps="default"
+    )  # TODO: need to fix now!
 
 visualise(
     preprocess_data,

--- a/spikewrap/examples/example_visualise.py
+++ b/spikewrap/examples/example_visualise.py
@@ -1,24 +1,27 @@
+from spikewrap.pipeline.load_data import load_data
 from spikewrap.pipeline.preprocess import preprocess
 from spikewrap.pipeline.visualise import visualise
-from spikewrap.pipline.load_data import load_data
 
-base_path = r"X:\neuroinformatics\scratch\jziminski\ephys\test_data\steve_multi_run\1119617\time-short"
+base_path = r"C:\data\ephys\test_data\steve_multi_run\1119617\time-short"
 sub_name = "1119617"
-run_names = "1119617_LSE1_shank12"
+run_names = [
+    "1119617_LSE1_shank12_g0",
+    #  "1119617_posttest1_shank12_g0",
+    #  "1119617_pretest1_shank12_g0",
+]
 
-data = load_data.load_data(base_path, sub_name, run_names, "spikeglx")
+
+data = load_data(base_path, sub_name, run_names, "spikeglx")
 
 for run_name in run_names:
-    preprocess_data = preprocess(
-        data, run_name, pp_steps="default"
-    )  # TODO: need to fix now!
+    preprocess_data = preprocess(data, run_name, pp_steps="default")
 
-visualise(
-    preprocess_data,
-    steps=["all"],
-    mode="map",
-    as_subplot=True,
-    show_channel_ids=True,
-    time_range=(0, 1),
-    run_number=1,
-)
+    visualise(
+        preprocess_data,
+        run_name,
+        steps=["all"],
+        mode="map",
+        as_subplot=True,
+        show_channel_ids=False,
+        time_range=(0, 1),
+    )

--- a/spikewrap/examples/example_visualise_preprocessing_output.py
+++ b/spikewrap/examples/example_visualise_preprocessing_output.py
@@ -1,11 +1,28 @@
 from pathlib import Path
 
-from spikewrap.pipeline.load_data import load_data_for_sorting
+from spikewrap.data_classes.sorting import SortingData
 from spikewrap.pipeline.visualise import visualise
 
-preprocessing_path = r"X:\neuroinformatics\scratch\jziminski\ephys\test_data\steve_multi_run\1119617\time-short\derivatives\1119617\1119617_LSE1_shank12_posttest1_pretest1\preprocessed"
+# WARNING ------------------- THIS DOES NOT CURRENTLY WORK ----------------------------#
 
-sorting_data = load_data_for_sorting(
-    Path(preprocessing_path),
+# TODO: move this into a convenience wrapper.
+# TODO: need to completely rework this in lgiht of recent refactorings.
+#
+base_path = Path(r"C:\data\ephys\test_data\steve_multi_run\1119617\time-short")
+sub_name = "1119617"
+run_names = [
+    "1119617_LSE1_shank12_g0",
+    #    "1119617_posttest1_shank12_g0",
+    #    "1119617_pretest1_shank12_g0",
+]
+
+sorting_data = SortingData(
+    base_path,
+    sub_name,
+    run_names,
+    sorter="kilsort2_5",  # This does nothing here
+    concat_for_sorting=False,  # TODO: this is a bad variable name here.
 )
-visualise(sorting_data, time_range=(1, 2))
+
+for run_name in run_names:
+    visualise(sorting_data, run_name, time_range=(1, 2))

--- a/spikewrap/pipeline/full_pipeline.py
+++ b/spikewrap/pipeline/full_pipeline.py
@@ -156,7 +156,6 @@ def run_full_pipeline(
 
     # Run Postprocessing
     for run_name in sorting_data.get_all_run_names():
-
         sorting_path = sorting_data.get_sorting_path(run_name)
 
         postprocess_data = run_postprocess(
@@ -194,7 +193,6 @@ def preprocess_and_save(
     See `run_full_pipeline()` for details.
     """
     for run_name in preprocess_data.run_names:
-
         utils.message_user(f"Preprocessing run {run_name}...")
 
         preprocess_path = preprocess_data.get_preprocessing_path(run_name)

--- a/spikewrap/pipeline/full_pipeline.py
+++ b/spikewrap/pipeline/full_pipeline.py
@@ -29,7 +29,7 @@ def run_full_pipeline(
     run_names: Union[List[str], str],
     config_name: str = "default",
     sorter: str = "kilosort2_5",
-    concat_for_sorting: bool = True,
+    concat_for_sorting: bool = False,
     existing_preprocessed_data: HandleExisting = "load_if_exists",
     existing_sorting_output: HandleExisting = "load_if_exists",
     overwrite_postprocessing: bool = False,
@@ -156,6 +156,7 @@ def run_full_pipeline(
 
     # Run Postprocessing
     for run_name in sorting_data.get_all_run_names():
+
         sorting_path = sorting_data.get_sorting_path(run_name)
 
         postprocess_data = run_postprocess(
@@ -193,6 +194,9 @@ def preprocess_and_save(
     See `run_full_pipeline()` for details.
     """
     for run_name in preprocess_data.run_names:
+
+        utils.message_user(f"Preprocessing run {run_name}...")
+
         preprocess_path = preprocess_data.get_preprocessing_path(run_name)
 
         if existing_preprocessed_data == "load_if_exists":
@@ -204,7 +208,7 @@ def preprocess_and_save(
                 continue  # sorting will automatically use the existing data
             else:
                 utils.message_user(
-                    f"No data found at {preprocess_path}, saving" f"preprocessed data."
+                    f"No data found at {preprocess_path}, saving preprocessed data."
                 )
                 overwrite = False
 

--- a/spikewrap/pipeline/full_pipeline.py
+++ b/spikewrap/pipeline/full_pipeline.py
@@ -3,13 +3,13 @@ from __future__ import annotations
 import copy
 import shutil
 from pathlib import Path
-from typing import TYPE_CHECKING, Dict, List, Literal, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Dict, List, Literal, Optional, Union
 
 from ..configs.configs import get_configs
 from ..data_classes.preprocessing import PreprocessingData
 from ..data_classes.sorting import SortingData
 from ..utils import logging_sw, slurm, utils
-from ..utils.custom_types import HandleExisting
+from ..utils.custom_types import DeleteIntermediate, HandleExisting
 from .load_data import load_data
 from .postprocess import run_postprocess
 from .preprocess import preprocess
@@ -34,9 +34,7 @@ def run_full_pipeline(
     existing_sorting_output: HandleExisting = "load_if_exists",
     overwrite_postprocessing: bool = False,
     postprocessing_to_run: Union[Literal["all"], Dict] = "all",
-    delete_intermediate_files: Tuple[
-        Literal["recording.dat", "temp_wh.dat", "waveforms"]
-    ] = ("recording.dat",),
+    delete_intermediate_files: DeleteIntermediate = ("recording.dat",),
     verbose: bool = True,
     slurm_batch: bool = False,
 ) -> None:
@@ -105,7 +103,7 @@ def run_full_pipeline(
         all available postprocessing. Otherwise, provide a dict of
         including postprocessing to run e.g. {"quality_metrics: True"}.
 
-    delete_intermediate_files : Tuple[Union["preprocessing", "recording.dat", "temp_wh.dat", "waveforms"]]  # TODO: check types
+    delete_intermediate_files : DeleteIntermediate
         Specify intermediate files or folders to delete. This option is useful for
         reducing the size of output data by deleting unneeded files.
 
@@ -244,9 +242,7 @@ def preprocess_and_save(
 def handle_delete_intermediate_files(
     run_name: Optional[str],
     sorting_data: SortingData,
-    delete_intermediate_files: Tuple[
-        Literal["recording.dat", "temp_wh.dat", "waveforms"]
-    ],
+    delete_intermediate_files: DeleteIntermediate,
 ):
     """
     Handle the cleanup of intermediate files created during sorting and

--- a/spikewrap/pipeline/load_data.py
+++ b/spikewrap/pipeline/load_data.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import spikeinterface.extractors as se
-from spikeinterface import append_recordings
 
 from ..data_classes.preprocessing import PreprocessingData
 from ..data_classes.sorting import SortingData
@@ -55,6 +54,7 @@ def load_data(base_path, sub_name, run_names, data_format="spikeglx"):
 
 def load_data_for_sorting(
     preprocessed_data_path: Path,
+    sorter: str,
     concatenate: bool = True,
 ) -> SortingData:
     """
@@ -85,6 +85,8 @@ def load_data_for_sorting(
     """
     sorting_data = SortingData(
         preprocessed_data_path,
+        sorter=sorter,
+        concat_for_sorting=concatenate,  # TODO: fix
     )
 
     sorting_data.load_preprocessed_binary(concatenate)
@@ -105,9 +107,10 @@ def load_spikeglx_data(preprocess_data: PreprocessingData) -> PreprocessingData:
 
     See load_data() for parameters.
     """
-    all_recordings = []
-    all_sync = []
-    for run_path in preprocess_data.all_run_paths:
+    for run_name in preprocess_data.run_names:
+        run_path = preprocess_data.get_run_path(run_name)
+        assert run_name == run_path.name, "TODO"
+
         with_sync, without_sync = [
             se.read_spikeglx(
                 folder_path=run_path,
@@ -117,15 +120,9 @@ def load_spikeglx_data(preprocess_data: PreprocessingData) -> PreprocessingData:
             )
             for sync in [True, False]
         ]
-        all_recordings.append(without_sync)
-        sync_channel_id = with_sync.get_channel_ids()[-1]
-        all_sync.append(with_sync.channel_slice(channel_ids=[sync_channel_id]))
+        preprocess_data[run_name]["0-raw"] = without_sync
+        preprocess_data.sync[run_name] = with_sync
 
-    preprocess_data["0-raw"] = append_recordings(all_recordings)
-    preprocess_data.sync = append_recordings(all_sync)
-
-    utils.message_user(
-        f"Raw session data was loaded from " f"{preprocess_data.all_run_paths}"
-    )
+        utils.message_user(f"Raw session data was loaded from " f"{run_path}")
 
     return preprocess_data

--- a/spikewrap/pipeline/load_data.py
+++ b/spikewrap/pipeline/load_data.py
@@ -1,18 +1,22 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, List, Union
 
 import spikeinterface.extractors as se
 
 from ..data_classes.preprocessing import PreprocessingData
-from ..data_classes.sorting import SortingData
 from ..utils import utils
 
 if TYPE_CHECKING:
     from pathlib import Path
 
 
-def load_data(base_path, sub_name, run_names, data_format="spikeglx"):
+def load_data(
+    base_path: Union[Path, str],
+    sub_name: str,
+    run_names: Union[str, List[str]],
+    data_format: str = "spikeglx",
+):
     """
     Load raw data (in rawdata). If multiple runs are selected
     in run_names, these will be stored as segments on a SpikeInterface
@@ -50,48 +54,6 @@ def load_data(base_path, sub_name, run_names, data_format="spikeglx"):
 
     if data_format == "spikeglx":
         return load_spikeglx_data(empty_data_class)
-
-
-def load_data_for_sorting(
-    preprocessed_data_path: Path,
-    sorter: str,
-    concatenate: bool = True,
-) -> SortingData:
-    """
-    Returns the previously preprocessed PreprocessingData and
-    recording object loaded from the preprocess path.
-
-    During sorting, preprocessed data is saved to
-    derivatives/<sub level dirs>/preprocessed. The spikeinterface
-    recording (si_recording) and PreprocessingData (data_class.pkl) are saved.
-
-    Parameters
-    ----------
-    preprocessed_data_path : Path
-        Path to the preprocessed folder, containing the binary si_recording
-        of the preprocessed data and the data_class.pkl containing all filepath
-        information.
-
-    concatenate : bool
-        If True, the multi-segment recording object will be concatenated
-        together. This is used prior to sorting. Segments should be
-        experimental runs.
-
-    Returns
-    -------
-    sorting_data : SortingData
-        The sorting_data dict with the loaded spikeinterface
-        recording attached to the '0-preprocessed' field.
-    """
-    sorting_data = SortingData(
-        preprocessed_data_path,
-        sorter=sorter,
-        concat_for_sorting=concatenate,  # TODO: fix
-    )
-
-    sorting_data.load_preprocessed_binary(concatenate)
-
-    return sorting_data
 
 
 # --------------------------------------------------------------------------------------

--- a/spikewrap/pipeline/postprocess.py
+++ b/spikewrap/pipeline/postprocess.py
@@ -94,6 +94,8 @@ def run_postprocess(
         "full_pipeline",
     )
 
+    utils.message_user(f"Postprocessing run: {postprocess_data.sorted_run_name}...")
+
     handle_delete_existing_postprocessing(
         postprocess_data.get_postprocessing_path(),
         overwrite_postprocessing,

--- a/spikewrap/pipeline/postprocess.py
+++ b/spikewrap/pipeline/postprocess.py
@@ -1,28 +1,24 @@
 from __future__ import annotations
 
+import shutil
 import time
 import warnings
 from pathlib import Path
 from typing import TYPE_CHECKING, Dict, Literal, Optional, Union
 
 import matplotlib.pyplot as plt
-import numpy
 import numpy as np
 import pandas as pd
 import spikeinterface as si
-from spikeinterface import curation
-from spikeinterface.extractors import NpzSortingExtractor
 
 from ..configs.configs import get_configs
-from ..data_classes.sorting import SortingData
-from ..pipeline.load_data import load_data_for_sorting
+from ..data_classes.postprocessing import PostprocessingData
 from ..utils import logging_sw, utils
 from ..utils.custom_types import HandleExisting
 from .waveform_compare import get_waveform_similarity
 
 if TYPE_CHECKING:
     from spikeinterface import WaveformExtractor
-    from spikeinterface.core import BaseSorting
 
 MATRIX_BACKEND: Literal["numpy", "jax"]
 try:
@@ -41,13 +37,13 @@ except ImportError:
 
 
 def run_postprocess(
-    sorting_data: Union[Path, str, SortingData],
-    sorter: str,
+    sorting_path: Union[Path, str],
+    overwrite_postprocessing: bool = False,
     existing_waveform_data: HandleExisting = "load_if_exists",
     postprocessing_to_run: Union[Literal["all"], Dict] = "all",
     verbose: bool = True,
     waveform_options: Optional[Dict] = None,
-) -> None:
+) -> PostprocessingData:
     """
     Run post-processing, including ave quality metrics on sorting
     output to a quality_metrics.csv file.
@@ -90,48 +86,53 @@ def run_postprocess(
         A dictionary containing options passed to SpikeInterface's
         `extract_waveforms()` function as kwargs.
     """
-    if not isinstance(sorting_data, SortingData):
-        sorting_data = load_data_for_sorting(
-            Path(sorting_data),
-        )
-    assert isinstance(sorting_data, SortingData), "type narrow `sorting_data`."
+    postprocess_data = PostprocessingData(sorting_path)
 
-    logs = logging_sw.get_started_logger(sorting_data.logging_path, "postprocess")
+    logs = logging_sw.get_started_logger(
+        utils.get_logging_path(
+            postprocess_data.sorting_info["base_path"],
+            postprocess_data.sorting_info["sub_name"],
+        ),
+        "full_pipeline",
+    )
+
+    handle_delete_existing_postprocessing(
+        postprocess_data.get_postprocessing_path(),
+        overwrite_postprocessing,
+    )
 
     # Create / load waveforms
     if waveform_options is None:
         _, _, waveform_options = get_configs("default")
 
-    sorting_data.set_sorter_output_paths(sorter)
-
-    utils.message_user(
-        f"Quality Checks: sorting path used: {sorting_data.sorter_run_output_path}",
-        verbose,
-    )
-
     waveforms = run_or_get_waveforms(
-        sorting_data, existing_waveform_data, waveform_options, sorter, verbose
+        postprocess_data, existing_waveform_data, waveform_options, verbose
     )
 
     # Perform postprocessing
     run_settings = handle_postprocessing_to_run(postprocessing_to_run)
 
     if run_option(run_settings, "quality_metrics"):
-        save_quality_matrics(waveforms, sorting_data)
+        save_quality_metrics(waveforms, postprocess_data.get_quality_metrics_path())
 
     if run_option(run_settings, "unit_locations"):
-        save_unit_locations(waveforms, sorting_data)
-
-    if run_option(run_settings, "template_plots"):
-        save_plots_of_templates(sorting_data.postprocessing_output_path, waveforms)
-
-    if run_option(run_settings, "waveform_similarity"):
-        save_waveform_similarities(
-            sorting_data.postprocessing_output_path, waveforms, MATRIX_BACKEND
-        )
+        save_unit_locations(waveforms, postprocess_data.get_unit_locations_path())
 
     logs.stop_logging()
 
+    return postprocess_data
+
+
+# Remove these!
+#    if run_option(run_settings, "template_plots"):
+#        save_plots_of_templates(sorting_data.postprocessing_path, waveforms)
+
+#    if run_option(run_settings, "waveform_similarity"):
+#        save_waveform_similarities(
+#            sorting_data.postprocessing_path, waveforms, MATRIX_BACKEND
+#        )
+
+#    logs.stop_logging()
 
 # Sorting Loader -----------------------------------------------------------------------
 
@@ -141,46 +142,36 @@ def run_option(run_settings: Dict, option: str):
 
 
 def run_or_get_waveforms(
-    sorting_data: SortingData,
+    postprocess_data: PostprocessingData,
     existing_waveform_data: HandleExisting,
     waveform_options: Dict,
-    sorter: str,
     verbose: bool,
 ):
     """
     How to handle existing waveform output, either load, fail if exists or
     overwrite.
     """
-    if (
-        sorting_data.postprocessing_output_path.is_dir()
-        and existing_waveform_data == "load_if_exists"
-    ):
+    postprocessing_path = postprocess_data.get_postprocessing_path()
+
+    if postprocessing_path.is_dir() and existing_waveform_data == "load_if_exists":
         utils.message_user(
-            f"Loading existing waveforms from: "
-            f"{sorting_data.postprocessing_output_path}",
+            f"Loading existing waveforms from: " f"{postprocessing_path}",
             verbose,
         )
-        waveforms = si.load_waveforms(sorting_data.postprocessing_output_path)
+        waveforms = si.load_waveforms(postprocessing_path)
 
-    elif (
-        sorting_data.postprocessing_output_path.is_dir()
-        and existing_waveform_data == "fail_if_exists"
-    ):
+    elif postprocessing_path.is_dir() and existing_waveform_data == "fail_if_exists":
         raise RuntimeError(
-            f"Waveforms exist at {sorting_data.postprocessing_output_path} but "
+            f"Waveforms exist at {postprocessing_path} but "
             f"`existing_waveform_data` is 'fail_if_exists'."
         )
     else:
-        utils.message_user(
-            f"Saving waveforms to {sorting_data.postprocessing_output_path}"
-        )
-
-        sorting_without_excess_spikes = load_sorting_output(sorting_data, sorter)
+        utils.message_user(f"Saving waveforms to {postprocessing_path}")
 
         waveforms = si.extract_waveforms(
-            sorting_data.data["0-preprocessed"],
-            sorting_without_excess_spikes,
-            folder=sorting_data.postprocessing_output_path,
+            postprocess_data.preprocessed_recording,
+            postprocess_data.sorting_output,
+            folder=postprocessing_path,
             use_relative_path=True,
             overwrite=True,
             **waveform_options,
@@ -220,87 +211,41 @@ def handle_postprocessing_to_run(postprocessing_to_run: Union[Literal["all"], Di
         return run_settings
 
 
-def load_sorting_output(sorting_data: SortingData, sorter: str) -> BaseSorting:
+def handle_delete_existing_postprocessing(
+    postprocessing_path: Path, overwrite_postprocessing: bool
+):
     """
-    Load the output of a sorting run as a SpikeInterface SortingExtractor
-    object.
-
-    It is assumed sorting is performed on concatenated runs. As such,
-    only a single sorting segment is expected, and error raised
-    if there are more.
-
-    Automatically remove empty units, which complicate downstream
-    processing. Also, remove excess spikes, which are caused by
-    strange behaviour of KS returning spike times that occur
-    outside the number of samples in a recording. This is required
-    for waveform extraction in Spikeinterface.
-
-    Parameters
-    ----------
-
-    sorting_data : SortingData
-        An spikewrap SortingData object holding information about sorting
-
-    sorter : str
-        The sorter used (e.g. "kilosort2_5")
-
-    TODO
-    ----
-    In newer SpikeInterface version, `remove_empty_units()` is automatically
-    applied during `KiloSortSortingExtractor()`. We can simply use
-    this default rather than applying again here after pinning to newer
-    SI version. See  https://github.com/SpikeInterface/spikeinterface/issues/1760
+    If previous postprocessing output exists, it must be deleted before
+    the new postprocessing is run. As a safety measure, `overwrite_postprocessing`
+    must be set to `True` to perform the deletion.
     """
-    if not sorting_data.sorter_run_output_path.is_dir():
-        raise FileNotFoundError(
-            f"{sorter} output was not found at "
-            f"{sorting_data.sorter_run_output_path}.\n"
-            f"Quality metrics will not be generated."
-        )
-
-    assert (
-        len(sorting_data) == 1
-    ), "unexpected number of entries in `sorting_data` dict."
-
-    recording = sorting_data[sorting_data.init_data_key]
-
-    if "kilosort" in sorter:
-        sorting = si.extractors.read_kilosort(
-            folder_path=sorting_data.sorter_run_output_path,
-            keep_good_only=False,
-        )
-    elif sorter == "mountainsort5":
-        sorting = NpzSortingExtractor(
-            (sorting_data.sorter_run_output_path / "firings.npz").as_posix()
-        )
-
-    elif sorter == "tridesclous":
-        sorting = si.extractors.read_tridesclous(
-            folder_path=sorting_data.sorter_run_output_path.as_posix()
-        )
-
-    elif sorter == "spykingcircus":
-        sorting = si.extractors.read_spykingcircus(
-            folder_path=sorting_data.sorter_run_output_path.as_posix()
-        )
-
-    sorting = sorting.remove_empty_units()
-    sorting_without_excess_spikes = curation.remove_excess_spikes(sorting, recording)
-
-    return sorting_without_excess_spikes
+    if postprocessing_path.is_dir():
+        if overwrite_postprocessing:
+            utils.message_user(
+                f"Deleting existing postprocessing " f"output at {postprocessing_path}"
+            )
+            shutil.rmtree(postprocessing_path)
+        else:
+            raise RuntimeError(
+                f"Postprocessing output already exists at "
+                f"{postprocessing_path} "
+                f"but `overwrite_postprocessing` is `False`. Setting "
+                f"`overwrite_postprocessing` will delete the postprocessing "
+                f"folder and all it's contents."
+            )
 
 
 # Helpers ------------------------------------------------------------------------------
 
 
-def save_quality_matrics(waveforms: WaveformExtractor, sorting_data: SortingData):
+def save_quality_metrics(waveforms: WaveformExtractor, quality_metrics_path):
     """ """
     quality_metrics = si.qualitymetrics.compute_quality_metrics(waveforms)
-    quality_metrics.to_csv(sorting_data.quality_metrics_path)
-    utils.message_user(f"Quality metrics saved to {sorting_data.quality_metrics_path}")
+    quality_metrics.to_csv(quality_metrics_path)
+    utils.message_user(f"Quality metrics saved to {quality_metrics_path}")
 
 
-def save_unit_locations(waveforms: WaveformExtractor, sorting_data: SortingData):
+def save_unit_locations(waveforms: WaveformExtractor, unit_locations_path):
     """ """
     unit_locations = si.postprocessing.compute_unit_locations(
         waveforms, outputs="by_unit"
@@ -308,13 +253,13 @@ def save_unit_locations(waveforms: WaveformExtractor, sorting_data: SortingData)
     unit_locations_pandas = pd.DataFrame.from_dict(
         unit_locations, orient="index", columns=["x", "y"]
     )
-    unit_locations_pandas.to_csv(sorting_data.unit_locations_path)
+    unit_locations_pandas.to_csv(unit_locations_path)
 
-    utils.message_user(f"Unit locations saved to {sorting_data.unit_locations_path}")
+    utils.message_user(f"Unit locations saved to {unit_locations_path}")
 
 
 def save_waveform_similarities(
-    postprocessing_output_path: Path,
+    postprocessing_path: Path,
     waveforms: WaveformExtractor,
     backend: Literal["jax", "numpy"],
 ):
@@ -329,7 +274,7 @@ def save_waveform_similarities(
     Parameters
     ---------
 
-    postprocessing_output_path : Path
+    postprocessing_path : Path
         Pathlib object holding the output path where waveforms are saved
         and /images will be written.
 
@@ -342,7 +287,7 @@ def save_waveform_similarities(
     """
     utils.message_user("Saving waveform similarity matrices...\n")
 
-    matrices_out_path = postprocessing_output_path / "similarity_matrices"
+    matrices_out_path = postprocessing_path / "similarity_matrices"
     matrices_out_path.mkdir(exist_ok=True)
 
     t = time.perf_counter()
@@ -364,9 +309,7 @@ def save_waveform_similarities(
 # --------------------------------------------------------------------------------------
 
 
-def save_plots_of_templates(
-    postprocessing_output_path: Path, waveforms: WaveformExtractor
-):
+def save_plots_of_templates(postprocessing_path: Path, waveforms: WaveformExtractor):
     """
     Save a plot of all templates in 'waveforms/images' folder. The plot
     displays the template waveform are calculated in two ways
@@ -383,7 +326,7 @@ def save_plots_of_templates(
     Parameters
     ------
 
-    postprocessing_output_path : Path
+    postprocessing_path : Path
         Pathlib object holding the output path where waveforms are saved
         and /images will be written.
 
@@ -412,11 +355,9 @@ def save_plots_of_templates(
         plt.ylabel(y_label)
         plt.title(f"Unit {unit_id} Template")
 
-        output_folder = postprocessing_output_path / "template_plots"
+        output_folder = postprocessing_path / "template_plots"
         output_folder.mkdir(exist_ok=True)
-        plt.savefig(
-            postprocessing_output_path / "template_plots" / f"unit_{unit_id}.png"
-        )
+        plt.savefig(postprocessing_path / "template_plots" / f"unit_{unit_id}.png")
         plt.clf()
 
     utils.message_user(f"Saving plots of templates took: {time.perf_counter() - t}")

--- a/spikewrap/pipeline/preprocess.py
+++ b/spikewrap/pipeline/preprocess.py
@@ -31,6 +31,10 @@ def preprocess(
         paths to rawdata. The pp_steps attribute is set on
         this class during execution of this function.
 
+    run_name: str
+        Name of the run to preprocess. This should correspond to a
+        run_name in `preprocess_data.run_names`.
+
     pp_steps: either a pp_steps dictionary, or name of valid
               preprocessing .yaml file (without hte yaml extension).
               See configs/configs.py for details.
@@ -125,7 +129,7 @@ def check_and_sort_pp_steps(pp_steps: Dict, pp_funcs: Dict) -> Tuple[Dict, List[
 
 def validate_pp_steps(pp_steps: Dict):
     """
-    Ensure the pp_steps dictionary of preprocessing steps to
+    Ensure the pp_steps dictionary of preprocessing steps
     has number-order that makes sense. The preprocessing step numbers
     should start 1 at, and increase by 1 for each subsequent step.
     """
@@ -172,6 +176,10 @@ def perform_preprocessing_step(
     preprocess_data : PreprocessingData
         spikewrap PreprocessingData class (a UserDict in which key-values are
         the preprocessing chain name : spikeinterface recording objects).
+
+    run_name: str
+        Name of the run to preprocess. This should correspond to a
+        run_name in `preprocess_data.run_names`.
 
     pp_step_names : List[str]
         Ordered list of preprocessing step names that are being

--- a/spikewrap/pipeline/sort.py
+++ b/spikewrap/pipeline/sort.py
@@ -160,8 +160,9 @@ def run_sorting_on_all_runs(
     utils.message_user(f"Starting {sorting_data.sorter} sorting...")
 
     for run_name in sorting_data.get_all_run_names():
-
-        utils.message_user(f"Sorting run {sorting_data.get_output_run_name(run_name)}...")
+        utils.message_user(
+            f"Sorting run {sorting_data.get_output_run_name(run_name)}..."
+        )
 
         output_path = sorting_data.get_sorting_path(run_name)
 

--- a/spikewrap/pipeline/sort.py
+++ b/spikewrap/pipeline/sort.py
@@ -160,6 +160,9 @@ def run_sorting_on_all_runs(
     utils.message_user(f"Starting {sorting_data.sorter} sorting...")
 
     for run_name in sorting_data.get_all_run_names():
+
+        utils.message_user(f"Sorting run {sorting_data.get_output_run_name(run_name)}...")
+
         output_path = sorting_data.get_sorting_path(run_name)
 
         if output_path.is_dir():
@@ -181,7 +184,7 @@ def run_sorting_on_all_runs(
 
         ss.run_sorter(
             sorting_data.sorter,
-            sorting_data[run_name],
+            sorting_data[sorting_data.get_output_run_name(run_name)],
             output_folder=output_path,
             singularity_image=singularity_image,
             docker_image=docker_image,

--- a/spikewrap/pipeline/sort.py
+++ b/spikewrap/pipeline/sort.py
@@ -2,28 +2,26 @@ from __future__ import annotations
 
 import copy
 import os
-import shutil
-from pathlib import Path
-from typing import TYPE_CHECKING, Dict, Literal, Optional, Tuple, Union
-
-from ..utils import logging_sw
-
-if TYPE_CHECKING:
-    from ..data_classes.sorting import SortingData
-
-import platform
+from typing import Dict, Optional
 
 import spikeinterface.sorters as ss
 
-from ..pipeline.load_data import load_data_for_sorting
-from ..utils import checks, slurm, utils
+from ..data_classes.sorting import SortingData
+from ..utils import logging_sw, slurm, utils
+from ..utils.managing_images import (
+    get_image_run_settings,
+    move_singularity_image_if_required,
+)
 
 
 def run_sorting(
-    preprocessed_data_path: Union[Path, str],
-    sorter: str = "kilosort2_5",
+    base_path,
+    sub_name,
+    run_names,
+    sorter: str,
+    concat_for_sorting: bool,
     sorter_options: Optional[Dict] = None,
-    overwrite_existing_sorter_output: bool = False,
+    existing_sorting_output: bool = False,  # TODO: fix
     verbose: bool = True,
     slurm_batch: bool = False,
 ) -> SortingData:
@@ -61,46 +59,38 @@ def run_sorting(
         if running on an interactive job, or locally.
 
     """
-    preprocessed_data_path = Path(preprocessed_data_path)
+    logs = logging_sw.get_started_logger(
+        utils.get_logging_path(base_path, sub_name), "full_pipeline"
+    )
 
-    sorting_data = load_data_for_sorting(preprocessed_data_path)
-    sorting_data.set_sorter_output_paths(sorter)
+    sorting_data = SortingData(
+        base_path,
+        sub_name,
+        run_names,
+        sorter=sorter,
+        concat_for_sorting=concat_for_sorting,
+    )
 
     if slurm_batch:
         local_args = copy.deepcopy(locals())
         slurm.run_sorting_slurm(**local_args)
         return sorting_data
 
-    logs = logging_sw.get_started_logger(sorting_data.logging_path, "sorting")
-
     sorter_options_dict = validate_inputs(slurm_batch, sorter, sorter_options, verbose)
-
-    # Load preprocessed data from saved preprocess output path.
-    utils.message_user(
-        f"\nLoading binary preprocessed data from {preprocessed_data_path.as_posix()}\n"
-    )
 
     # This must be run from the folder that has both sorter output AND rawdata
     os.chdir(sorting_data.base_path)
 
     singularity_image, docker_image = get_image_run_settings(sorter)
 
-    utils.message_user(f"Starting {sorter} sorting...")
-
-    # TODO: can remove on API change PR #1908
-    # Also, once #1908 is merged and updated, we need to check
-    # that 'delete_intermediate_files' is not passed by the
-    # user in the config file because it is overridden here.
     if "kilosort" in sorter:
         sorter_options_dict.update({"delete_tmp_files": False})
 
-    ss.run_sorter(
-        sorter,
-        sorting_data.data["0-preprocessed"],
-        output_folder=sorting_data.sorting_output_path,
-        singularity_image=singularity_image,
-        docker_image=docker_image,
-        remove_existing_folder=overwrite_existing_sorter_output,
+    run_sorting_on_all_runs(
+        sorting_data,
+        singularity_image,
+        docker_image,
+        existing_sorting_output=existing_sorting_output,
         **sorter_options_dict,
     )
 
@@ -111,128 +101,56 @@ def run_sorting(
     return sorting_data
 
 
-def move_singularity_image_if_required(
-    sorting_data: SortingData,
-    singularity_image: Optional[Union[Literal[True], str]],
-    sorter: str,
-) -> None:
-    """
-    On Linux, images are cased to the sorting_data base folder
-    by default by SpikeInterface. To avoid re-downloading
-    images, these are moved to a pre-determined folder (home
-    for local, pre-set on an HPC). This is only required
-    for singularity, as docker-desktop handles all image
-    storage.
+def run_sorting_on_all_runs(
+    sorting_data,
+    singularity_image,
+    docker_image,
+    existing_sorting_output,
+    **sorter_options_dict,
+):
+    """ """
+    utils.message_user(f"Starting {sorting_data.sorter} sorting...")
 
-    Parameters
-    ----------
+    #    if sorting_data.concat_for_sorting:
+    #        run_names = [sorting_data.concat_run_name()]
+    #        output_paths = [sorting_data.get_sorting_path(run_name=None)]  # TODO: figure out this confusing thing?
+    #    else:
+    #        run_names = sorting_data.run_names
+    #        output_paths = [sorting_data.get_sorting_path(run_name) for run_name in sorting_data.run_names]
 
-    singularity_image: Optional[Union[Literal[True], Path]]
-        Holds either a path to an existing (stored) sorter, or
-        `True`. If `True`, no stored sorter image exists and so
-        we move it. The next time sorting is performed, it will use
-        this stored image.
+    #    for run_name, output_path in zip(run_names, output_paths):
 
-    sorter : str
-        Name of the sorter.
-    """
-    if singularity_image is True:
-        assert (
-            platform.system() == "Linux"
-        ), "Docker Desktop should be used on Windows or macOS."
-        store_singularity_image(sorting_data.base_path, sorter)
+    for run_name in sorting_data.get_all_run_names():
+        output_path = sorting_data.get_sorting_path(run_name)
 
+        if output_path.is_dir():
+            if existing_sorting_output == "fail_if_exists":
+                raise RuntimeError(
+                    f"Sorting output already exists at {output_path} and"
+                    f"`existing_sorting_output` is set to 'fail_if_exists'."
+                )
 
-def get_image_run_settings(
-    sorter: str,
-) -> Tuple[
-    Optional[Union[Literal[True], str]], Optional[bool]
-]:  # cannot set this to Literal[True], for unknown reason.
-    """
-    Determine how to run the sorting, either locally or in a container
-    if required (e.g. kilosort2_5). On windows, Docker is used,
-    otherwise singularity. Docker images are handled by Docker-desktop,
-    but singularity image storage is handled internally, see
-    `move_singularity_image_if_required()`.
+            elif existing_sorting_output == "load_if_exists":
+                utils.message_user(
+                    f"Sorting output already exists at {output_path}. Nothing "
+                    f"will be done. The existing sorting will be used for postprocessing "
+                    f"if running with `run_full_pipeline`"
+                )
+                continue
 
-    Parameters
-    ----------
+            quick_safety_check(existing_sorting_output, output_path)
 
-    sorter : str
-        Sorter name.
-    """
-    can_run_locally = ["spykingcircus", "mountainsort5", "tridesclous"]
+        ss.run_sorter(
+            sorting_data.sorter,
+            sorting_data[run_name],
+            output_folder=output_path,
+            singularity_image=singularity_image,
+            docker_image=docker_image,
+            remove_existing_folder=True,
+            **sorter_options_dict,
+        )
 
-    if sorter in can_run_locally:
-        singularity_image = docker_image = None
-    else:
-        if platform.system() == "Windows":
-            singularity_image = None
-            docker_image = True
-        else:
-            singularity_image = get_singularity_image(sorter)
-            docker_image = None
-
-    if singularity_image or docker_image:
-        assert checks._check_virtual_machine()
-
-        if platform.system != "Linux":
-            assert (
-                checks.docker_desktop_is_running()
-            ), "Docker is not running. Open Docker Desktop to start Docker."
-
-    return singularity_image, docker_image
-
-
-def store_singularity_image(base_path: Path, sorter: str) -> None:
-    """
-    When running locally, SpikeInterface will pull the docker image
-    to the current working directly. Move this to home/.spikewrap
-    so they can be used again in future and are centralised.
-
-    Parameters
-    ----------
-    base_path : Path
-        Base-path on the SortingData object, the path that holds
-        `rawdata` and `derivatives` folders.
-
-    sorter : str
-        Name of the sorter for which to store the image.
-    """
-    path_to_image = base_path / utils.get_sorter_image_name(sorter)
-    shutil.move(path_to_image, utils.get_local_sorter_path(sorter).parent)
-
-
-def get_singularity_image(sorter: str) -> Union[Literal[True], str]:
-    """
-    Get the path to a pre-installed system singularity image. If none
-    can be found, set to True. In this case SpikeInterface will
-    pull the image to the current working directory, and
-    this will be moved after sorting
-    (see store_singularity_image).
-
-    Parameters
-    ----------
-    sorter : str
-        Name of the sorter to get the image for.
-
-    Returns
-    -------
-    singularity_image [ Union[Literal[True], str]
-        If `str`, the path to the singularity image. Otherwise if `True`,
-        this tells SpikeInterface to pull the image.
-    """
-    singularity_image: Union[Literal[True], str]
-
-    if utils.get_hpc_sorter_path(sorter).is_file():
-        singularity_image = str(utils.get_hpc_sorter_path(sorter))
-
-    elif utils.get_local_sorter_path(sorter).is_file():
-        singularity_image = str(utils.get_local_sorter_path(sorter))
-    else:
-        singularity_image = True
-
-    return singularity_image
+        sorting_data.save_sorting_info(run_name)
 
 
 def validate_inputs(
@@ -280,10 +198,6 @@ def validate_inputs(
         sorter in supported_sorters
     ), f"sorter {sorter} is invalid, must be one of: {supported_sorters}"
 
-    assert (
-        utils.check_singularity_install()
-    ), "Singularity must be installed to run sorting."
-
     sorter_options_dict = {}
     if sorter_options is not None and sorter in sorter_options:
         sorter_options_dict = sorter_options[sorter]
@@ -291,3 +205,15 @@ def validate_inputs(
     sorter_options_dict.update({"verbose": verbose})
 
     return sorter_options_dict
+
+
+def quick_safety_check(existing_sorting_output, output_path):
+    """
+     In this case, either output path does not exist, or it does
+     and `existing_sorter_output` is "overwrite"
+
+    TODO: delete after some testing
+    """
+    assert existing_sorting_output != "fail_if_exists"
+    if existing_sorting_output == "load_if_exists":
+        assert not output_path.is_dir()

--- a/spikewrap/pipeline/visualise.py
+++ b/spikewrap/pipeline/visualise.py
@@ -78,7 +78,7 @@ def visualise(
             recordings = recording.split_by(property="group")
             recording_to_plot = recordings[shank_idx]
 
-            plot_title = utils.make_preprocessing_plot_title(
+            plot_title = make_preprocessing_plot_title(
                 run_name,
                 full_key,
                 shank_idx,
@@ -237,3 +237,53 @@ def validate_options_against_recording(
         assert (
             time_range[1] <= recording.get_times(segment_index=0)[-1]
         ), "The time range specified is longer than the maximum time of the recording."
+
+
+def make_preprocessing_plot_title(
+    run_name: str,
+    full_key: str,
+    shank_idx: int,
+    recording_to_plot: BaseRecording,
+    total_used_shanks: int,
+) -> str:
+    """
+    For visualising data, make the plot titles (with headers in bold). If
+    more than one shank is used, the title will also contain information
+    on the displayed shank.
+
+    Parameters
+    ----------
+    run_name : str
+        The name of the preprocessing run (e.g. "1-phase_shift").
+
+    full_key : str
+        The full preprocessing key (as defined in preprocess.py).
+
+    shank_idx : int
+        The SpikeInterface group number representing the shank number.
+
+    recording_to_plot : BaseRecording
+        The SpikeInterface recording object that is being displayed.
+
+    total_used_shanks : int
+        The total number of shanks used in the recording. For a 4-shank probe,
+        this could be between 1 - 4 if not all shanks are mapped.
+
+    Returns
+    -------
+    plot_title : str
+        The formatted plot title.
+    """
+    plot_title = (
+        r"$\bf{Run \ name:}$" + f"{run_name}"
+        "\n" + r"$\bf{Preprocessing \ step:}$" + f"{full_key}"
+    )
+    if total_used_shanks > 1:
+        plot_title += (
+            "\n"
+            + r"$\bf{Shank \ group:}$"
+            + f"{shank_idx}, "
+            + r"$\bf{Num \ channels:}$"
+            + f"{recording_to_plot.get_num_channels()}"
+        )
+    return plot_title

--- a/spikewrap/pipeline/visualise.py
+++ b/spikewrap/pipeline/visualise.py
@@ -18,12 +18,12 @@ if TYPE_CHECKING:
 
 def visualise(
     data: Union[PreprocessingData, SortingData],
+    run_name: str,
     steps: Union[List[str], str] = "all",
     mode: str = "auto",
     as_subplot: bool = False,
     time_range: Optional[Tuple] = None,
     show_channel_ids: bool = False,
-    run_number: int = 1,
 ) -> None:
     """
     Plot the data at various preprocessing steps, useful for quality-checking.
@@ -57,23 +57,26 @@ def visualise(
     run_number : The run number to visualise (in the case of a concatenated recording.
                  Under the hood, each run maps to a SpikeInterface segment_index.
     """
-    steps, as_subplot = process_input_arguments(data, steps, as_subplot)
+    steps, as_subplot = process_input_arguments(data, run_name, steps, as_subplot)
 
-    total_used_shanks = utils.get_probe_num_groups(data)
+    first_key = list(data[run_name].keys())[-1]
+    total_used_shanks = np.unique(
+        data[run_name][first_key].get_property("group")
+    ).size  # TODO
 
     for shank_idx in range(total_used_shanks):
         if as_subplot:
             fig, ax, num_rows, num_cols = generate_subplot(steps)
 
         for idx, step in enumerate(steps):
-            recording, full_key = utils.get_dict_value_from_step_num(data, str(step))
+            recording, full_key = utils.get_dict_value_from_step_num(
+                data[run_name], str(step)
+            )
 
-            validate_options_against_recording(recording, data, time_range, run_number)
+            validate_options_against_recording(recording, data, run_name, time_range)
 
             recordings = recording.split_by(property="group")
             recording_to_plot = recordings[shank_idx]
-
-            run_name = get_run_name(data, run_number)
 
             plot_title = utils.make_preprocessing_plot_title(
                 run_name,
@@ -95,7 +98,7 @@ def visualise(
                 show_channel_ids=show_channel_ids,
                 mode=mode,
                 ax=current_ax,
-                segment_index=run_number - 1,
+                segment_index=0,
             )
 
             if current_ax is None:
@@ -176,6 +179,7 @@ def get_subplot_ax(
 
 def process_input_arguments(
     data: Union[PreprocessingData, SortingData],
+    run_name: str,
     steps: Union[List[str], str],
     as_subplot: bool,
 ) -> Tuple[Union[List[str], str], bool]:
@@ -197,9 +201,9 @@ def process_input_arguments(
 
     if "all" in steps:
         assert len(steps) == 1, "if using 'all' only put one step input"
-        steps = utils.get_keys_first_char(data)  # type: ignore
+        steps = utils.get_keys_first_char(data[run_name])  # type: ignore
 
-    assert len(steps) <= len(data), (
+    assert len(steps) <= len(data[run_name]), (
         "The number of steps must be less or equal to the "
         "number of steps in the recording"
     )
@@ -213,8 +217,8 @@ def process_input_arguments(
 def validate_options_against_recording(
     recording: BaseRecording,
     data: Union[PreprocessingData, SortingData],
+    run_name: str,
     time_range: Optional[Tuple],
-    run_number: int,
 ) -> None:
     """
     Check the passed configurations are valid.
@@ -226,45 +230,10 @@ def validate_options_against_recording(
     but must be somewhere, this is wasteful.
     """
     if isinstance(data, PreprocessingData):
-        num_runs = len(data.run_names)
-        assert run_number <= num_runs, (
-            "The run_number must be less than or equal to the "
-            "number of runs specified."
-        )
+        assert (
+            run_name in data
+        ), "The run_name must be a key in the loaded `preprocessing_data` dict."
     if time_range is not None:
         assert (
-            time_range[1] <= recording.get_times(segment_index=run_number - 1)[-1]
+            time_range[1] <= recording.get_times(segment_index=0)[-1]
         ), "The time range specified is longer than the maximum time of the recording."
-
-
-def get_run_name(data: Union[PreprocessingData, SortingData], run_number: int) -> str:
-    """
-    Get the name of the run of which the data is being displayed.
-    If the object is PreprocessingData, the data is not concatenated
-    and it is one of the rawdata runs for the subject.
-
-    Otherwise it is a SortingData object, of which there is only one, concatenated
-    output run.
-
-    Parameters
-    ----------
-    data : Union[PreprocessingData, SortingData]
-        Preprocessing or sorting data dictionary.
-
-    run_number : int
-        Run of the run to plot.
-
-    Returns
-    -------
-    run_name : str
-        Name of the run. For PreprocessingData, this will be the raw
-        data run name. For SortingData, if multiple runs are
-        concatenated it will be an amalgamation of the rawdata
-        runs used to generated it.
-    """
-    if isinstance(data, PreprocessingData):
-        run_name = data.run_names[run_number - 1]
-    elif isinstance(data, SortingData):
-        run_name = data.pp_run_name
-
-    return run_name

--- a/spikewrap/pipeline/visualise.py
+++ b/spikewrap/pipeline/visualise.py
@@ -226,7 +226,7 @@ def validate_options_against_recording(
     but must be somewhere, this is wasteful.
     """
     if isinstance(data, PreprocessingData):
-        num_runs = len(data.all_run_names)
+        num_runs = len(data.run_names)
         assert run_number <= num_runs, (
             "The run_number must be less than or equal to the "
             "number of runs specified."
@@ -263,7 +263,7 @@ def get_run_name(data: Union[PreprocessingData, SortingData], run_number: int) -
         runs used to generated it.
     """
     if isinstance(data, PreprocessingData):
-        run_name = data.all_run_names[run_number - 1]
+        run_name = data.run_names[run_number - 1]
     elif isinstance(data, SortingData):
         run_name = data.pp_run_name
 

--- a/spikewrap/utils/custom_types.py
+++ b/spikewrap/utils/custom_types.py
@@ -2,5 +2,6 @@ from typing import Literal, Tuple
 
 HandleExisting = Literal["overwrite", "load_if_exists", "fail_if_exists"]
 DeleteIntermediate = Tuple[
-    Literal["recording.dat"], Literal["temp_wh.dat"], Literal["waveforms"]  # see #82
+    Union[Literal["recording.dat"], Literal["temp_wh.dat"], Literal["waveforms"]], ...
 ]
+

--- a/spikewrap/utils/custom_types.py
+++ b/spikewrap/utils/custom_types.py
@@ -1,7 +1,6 @@
-from typing import Literal, Tuple
+from typing import Literal, Tuple, Union
 
 HandleExisting = Literal["overwrite", "load_if_exists", "fail_if_exists"]
 DeleteIntermediate = Tuple[
     Union[Literal["recording.dat"], Literal["temp_wh.dat"], Literal["waveforms"]], ...
 ]
-

--- a/spikewrap/utils/custom_types.py
+++ b/spikewrap/utils/custom_types.py
@@ -1,3 +1,6 @@
-from typing import Literal
+from typing import Literal, Tuple
 
 HandleExisting = Literal["overwrite", "load_if_exists", "fail_if_exists"]
+DeleteIntermediate = Tuple[
+    Literal["recording.dat"], Literal["temp_wh.dat"], Literal["waveforms"]  # see #82
+]

--- a/spikewrap/utils/logging_sw.py
+++ b/spikewrap/utils/logging_sw.py
@@ -2,9 +2,10 @@ from __future__ import annotations
 
 import logging
 import sys
-from datetime import datetime
 from pathlib import Path
 from typing import Literal, Union
+
+from . import utils
 
 
 class HandleLogging:
@@ -176,7 +177,7 @@ def get_started_logger(
     Convenience function that creates logger name and stars a
     HandleLogging() instance.
     """
-    format_datetime = datetime.now().strftime("%Y-%m-%d_%H%M%S")
+    format_datetime = utils.get_formatted_datetime()
     log_name = f"{format_datetime}_{run_name}.log"
 
     logs = HandleLogging()

--- a/spikewrap/utils/managing_images.py
+++ b/spikewrap/utils/managing_images.py
@@ -74,7 +74,7 @@ def get_image_run_settings(
     if singularity_image or docker_image:
         assert checks._check_virtual_machine()
 
-        if platform.system != "Linux":
+        if platform.system() != "Linux":
             assert (
                 checks.docker_desktop_is_running()
             ), "Docker is not running. Open Docker Desktop to start Docker."

--- a/spikewrap/utils/managing_images.py
+++ b/spikewrap/utils/managing_images.py
@@ -1,0 +1,200 @@
+from __future__ import annotations
+
+import platform
+import shutil
+from pathlib import Path
+from typing import TYPE_CHECKING, Literal, Optional, Tuple, Union
+
+from . import checks
+
+if TYPE_CHECKING:
+    from ..data_classes.sorting import SortingData
+
+
+def move_singularity_image_if_required(
+    sorting_data: SortingData,
+    singularity_image: Optional[Union[Literal[True], str]],
+    sorter: str,
+) -> None:
+    """
+    On Linux, images are cased to the sorting_data base folder
+    by default by SpikeInterface. To avoid re-downloading
+    images, these are moved to a pre-determined folder (home
+    for local, pre-set on an HPC). This is only required
+    for singularity, as docker-desktop handles all image
+    storage.
+
+    Parameters
+    ----------
+
+    singularity_image: Optional[Union[Literal[True], Path]]
+        Holds either a path to an existing (stored) sorter, or
+        `True`. If `True`, no stored sorter image exists and so
+        we move it. The next time sorting is performed, it will use
+        this stored image.
+
+    sorter : str
+        Name of the sorter.
+    """
+    if singularity_image is True:
+        assert (
+            platform.system() == "Linux"
+        ), "Docker Desktop should be used on Windows or macOS."
+        store_singularity_image(sorting_data.base_path, sorter)
+
+
+def get_image_run_settings(
+    sorter: str,
+) -> Tuple[
+    Optional[Union[Literal[True], str]], Optional[bool]
+]:  # cannot set this to Literal[True], for unknown reason.
+    """
+    Determine how to run the sorting, either locally or in a container
+    if required (e.g. kilosort2_5). On windows, Docker is used,
+    otherwise singularity. Docker images are handled by Docker-desktop,
+    but singularity image storage is handled internally, see
+    `move_singularity_image_if_required()`.
+
+    Parameters
+    ----------
+
+    sorter : str
+        Sorter name.
+    """
+    can_run_locally = ["spykingcircus", "mountainsort5", "tridesclous"]
+
+    if sorter in can_run_locally:
+        singularity_image = docker_image = None
+    else:
+        if platform.system() == "Windows":
+            singularity_image = None
+            docker_image = True
+        else:
+            singularity_image = get_singularity_image(sorter)
+            docker_image = None
+
+    if singularity_image or docker_image:
+        assert checks._check_virtual_machine()
+
+        if platform.system != "Linux":
+            assert (
+                checks.docker_desktop_is_running()
+            ), "Docker is not running. Open Docker Desktop to start Docker."
+
+    return singularity_image, docker_image
+
+
+def store_singularity_image(base_path: Path, sorter: str) -> None:
+    """
+    When running locally, SpikeInterface will pull the docker image
+    to the current working directly. Move this to home/.spikewrap
+    so they can be used again in future and are centralised.
+
+    Parameters
+    ----------
+    base_path : Path
+        Base-path on the SortingData object, the path that holds
+        `rawdata` and `derivatives` folders.
+
+    sorter : str
+        Name of the sorter for which to store the image.
+    """
+    path_to_image = base_path / get_sorter_image_name(sorter)
+    shutil.move(path_to_image, get_local_sorter_path(sorter).parent)
+
+
+def get_singularity_image(sorter: str) -> Union[Literal[True], str]:
+    """
+    Get the path to a pre-installed system singularity image. If none
+    can be found, set to True. In this case SpikeInterface will
+    pull the image to the current working directory, and
+    this will be moved after sorting
+    (see store_singularity_image).
+
+    Parameters
+    ----------
+    sorter : str
+        Name of the sorter to get the image for.
+
+    Returns
+    -------
+    singularity_image [ Union[Literal[True], str]
+        If `str`, the path to the singularity image. Otherwise if `True`,
+        this tells SpikeInterface to pull the image.
+    """
+    singularity_image: Union[Literal[True], str]
+
+    if get_hpc_sorter_path(sorter).is_file():
+        singularity_image = str(get_hpc_sorter_path(sorter))
+
+    elif get_local_sorter_path(sorter).is_file():
+        singularity_image = str(get_local_sorter_path(sorter))
+    else:
+        singularity_image = True
+
+    return singularity_image
+
+
+def get_local_sorter_path(sorter: str) -> Path:
+    """
+    Return the path to a sorter singularity image. The sorters are
+    stored by spikewrap in the home folder.
+
+    Parameters
+    ----------
+    sorter : str
+        The name of the sorter to get the path to (e.g. kilosort2_5).
+
+    Returns
+    ---------
+    local_path : Path
+        The path to the sorter image on the local machine.
+    """
+    local_path = (
+        Path.home() / ".spikewrap" / "sorter_images" / get_sorter_image_name(sorter)
+    )
+    local_path.parent.mkdir(exist_ok=True, parents=True)
+    return local_path
+
+
+def get_hpc_sorter_path(sorter: str) -> Path:
+    """
+    Return the path to the sorter image on the SWC HCP (ceph).
+
+    Parameters
+    ----------
+    sorter : str
+        The name of the sorter to get the path to (e.g. kilosort2_5).
+
+    Returns
+    -------
+    sorter_path : Path
+        The base to the sorter image on SWC HCP (ceph).
+    """
+    base_path = Path("/ceph/neuroinformatics/neuroinformatics/scratch/sorter_images")
+    sorter_path = base_path / sorter / get_sorter_image_name(sorter)
+    return sorter_path
+
+
+def get_sorter_image_name(sorter: str) -> str:
+    """
+    Get the sorter image name, as defined by how
+    SpikeInterface names the docker images it provides.
+
+    Parameters
+    ----------
+    sorter : str
+        The name of the sorter to get the path to (e.g. kilosort2_5).
+
+    Returns
+    -------
+    sorter_name : str
+        The SpikeInterface filename of the docker image for that sorter.
+    """
+    if "kilosort" in sorter:
+        sorter_name = f"{sorter}-compiled-base.sif"
+    else:
+        if sorter == "spykingcircus":
+            sorter = "spyking-circus"
+        sorter_name = f"{sorter}-base.sif"
+    return sorter_name

--- a/spikewrap/utils/managing_images.py
+++ b/spikewrap/utils/managing_images.py
@@ -45,9 +45,7 @@ def move_singularity_image_if_required(
 
 def get_image_run_settings(
     sorter: str,
-) -> Tuple[
-    Optional[Union[Literal[True], str]], Optional[bool]
-]:  # cannot set this to Literal[True], for unknown reason.
+) -> Tuple[Optional[Union[Literal[True], str]], Optional[Literal[True]]]:
     """
     Determine how to run the sorting, either locally or in a container
     if required (e.g. kilosort2_5). On windows, Docker is used,
@@ -81,7 +79,7 @@ def get_image_run_settings(
                 checks.docker_desktop_is_running()
             ), "Docker is not running. Open Docker Desktop to start Docker."
 
-    return singularity_image, docker_image
+    return singularity_image, docker_image  # type: ignore
 
 
 def store_singularity_image(base_path: Path, sorter: str) -> None:

--- a/spikewrap/utils/utils.py
+++ b/spikewrap/utils/utils.py
@@ -119,8 +119,10 @@ def get_dict_value_from_step_num(
 
     select_step_pp_key = [key for key in data.keys() if key.split("-")[0] == step_num]
 
-    assert len(select_step_pp_key) == 1, "pp_key must always have unique first char"
-
+    try:
+        assert len(select_step_pp_key) == 1, "pp_key must always have unique first char"
+    except:
+        breakpoint()
     pp_key: str = select_step_pp_key[0]
     dict_value = data[pp_key]
 
@@ -235,29 +237,3 @@ def load_dict_from_yaml(filepath):
     with open(filepath, "r") as file:
         loaded_dict = yaml.safe_load(file)
     return loaded_dict
-
-
-# Misc. --------------------------------------------------------------------------------
-
-
-def get_probe_num_groups(data: Union[PreprocessingData, SortingData]) -> int:
-    """
-    Get the number of probe groups on a recording-objects `probe` attribute.
-    This is typically the number of shanks on the probe, which are treated
-    separately by SI.
-
-    By default, uses the first step on the recording, as probe metadata will not
-    change throughout preprocessing.
-
-    Parameters
-    ----------
-    data : Union[PreprocessingData, SortingData]
-        The data object on which the recordings are stored.
-
-    Returns
-    -------
-    num_groups : int
-        The number of groups on the probe associated with the data recordings.
-    """
-    num_groups = np.unique(data[data.init_data_key].get_property("group")).size
-    return num_groups

--- a/tests/test_integration/test_initial.py
+++ b/tests/test_integration/test_initial.py
@@ -10,7 +10,7 @@ from spikeinterface import concatenate_recordings
 
 from spikewrap.pipeline import full_pipeline, preprocess
 from spikewrap.pipeline.full_pipeline import get_configs
-from spikewrap.pipeline.load_data import load_spikeglx_data
+from spikewrap.pipeline.load_data import load_data
 from spikewrap.utils.slurm import is_slurm_installed
 
 CAN_SLURM = is_slurm_installed()
@@ -18,34 +18,34 @@ CAN_SLURM = is_slurm_installed()
 
 class TestFirstEphys:
     @pytest.fixture(scope="class")
-    def output_data_path(self):
+    def base_path(self):
         script_path = Path(os.path.dirname(os.path.realpath(__file__)))
         data_path = script_path.parent
-        output_data_path = data_path / "data" / "steve_multi_run"
-        return output_data_path
+        base_path = data_path / "data" / "steve_multi_run"
+        return base_path
 
     @pytest.fixture(scope="function")
-    def test_info(self, output_data_path, request):
+    def test_info(self, base_path, request):
         """ """
         if not hasattr(request, "param"):
             mode = "time-short"
         else:
             mode = request.param
 
-        output_data_path = output_data_path / mode
+        base_path = base_path / mode
 
         sub_name = "1119617"
         run_names = [
-            "1119617_LSE1_shank12",
-            "1119617_posttest1_shank12",
-            "1119617_pretest1_shank12",
+            "1119617_LSE1_shank12_g0",
+            "1119617_posttest1_shank12_g0",
+            "1119617_pretest1_shank12_g0",
         ]
 
-        output_path = output_data_path / "derivatives"
+        output_path = base_path / "derivatives"
         if output_path.is_dir():
             shutil.rmtree(output_path)
 
-        yield [output_data_path, sub_name, run_names, output_path]
+        yield [base_path, sub_name, run_names]
 
         if output_path.is_dir():
             shutil.rmtree(output_path)
@@ -55,10 +55,11 @@ class TestFirstEphys:
         base_path,
         sub_name,
         run_names,
+        sorter="kilosort2_5",
+        concat_for_sorting=False,
         existing_preprocessed_data="fail_if_exists",
         existing_sorting_output="fail_if_exists",
         slurm_batch=False,
-        sorter="kilosort2_5",
     ):
         full_pipeline.run_full_pipeline(
             base_path,
@@ -66,6 +67,7 @@ class TestFirstEphys:
             run_names,
             config_name="default",
             sorter=sorter,
+            concat_for_sorting=concat_for_sorting,
             existing_preprocessed_data=existing_preprocessed_data,
             existing_sorting_output=existing_sorting_output,
             overwrite_postprocessing=True,
@@ -77,10 +79,12 @@ class TestFirstEphys:
         """"""
         pp_steps, __, __ = get_configs("test_pp_small_file")
 
-        preprocess_data = load_spikeglx_data(*test_info[:3])
+        preprocess_data = load_data(*test_info[:3], data_format="spikeglx")
 
-        preprocess_data = preprocess.preprocess(preprocess_data, pp_steps, verbose=True)
-        preprocess_data.save_all_preprocessed_data(overwrite=True)
+        for run_name in preprocess_data.run_names:
+            preprocess_data = preprocess.preprocess(preprocess_data, run_name, pp_steps, verbose=True)
+
+            preprocess_data.save_preprocessed_data(run_name, overwrite=True)
 
     def test_preprocessing_options_with_large_file(self, test_info):
         """
@@ -90,12 +94,11 @@ class TestFirstEphys:
         """
         pp_steps, __, __ = get_configs("test_pp_large_file")
 
-        preprocess_data = load_spikeglx_data(*test_info[:3])
-        # motion correction requires only 1 segment
-        preprocess_data["0-raw"] = concatenate_recordings([preprocess_data["0-raw"]])
+        preprocess_data = load_data(*test_info[:3])
 
-        preprocess_data = preprocess.preprocess(preprocess_data, pp_steps, verbose=True)
-        preprocess_data.save_all_preprocessed_data(overwrite=True)
+        for run_name in preprocess_data.run_names:
+            preprocess_data = preprocess.preprocess(preprocess_data, run_name, pp_steps, verbose=True)
+            preprocess_data.save_preprocessed_data(run_name, overwrite=True)
 
     @pytest.mark.parametrize(
         "sorter",
@@ -104,22 +107,22 @@ class TestFirstEphys:
             "kilosort2_5",
             "kilosort3",
             "mountainsort5",
-            "spykingcircus",
+            "spykingcircus2",
             "tridesclous",
         ],
     )
     def test_single_run_local__(self, test_info, sorter):
-        test_info.pop(3)
         test_info[2] = test_info[2][0]
-        self.run_full_pipeline(*test_info, sorter=sorter)
+        self.run_full_pipeline(*test_info, sorter=sorter, concat_for_sorting=False)
 
     def test_single_run_local_overwrite(self, test_info):
-        test_info.pop(3)
         test_info[2] = test_info[2][0]
 
         self.run_full_pipeline(*test_info)
 
-        self.run_full_pipeline(*test_info, existing_preprocessed_data="overwrite")
+        self.run_full_pipeline(*test_info,
+                               existing_preprocessed_data="overwrite",
+                               existing_sorting_output="overwrite")
 
         with pytest.raises(BaseException) as e:
             self.run_full_pipeline(
@@ -131,26 +134,38 @@ class TestFirstEphys:
         )
 
     def test_multi_run_local(self, test_info):
-        test_info.pop(3)
 
         test_info[2] = test_info[2][0]
 
         self.run_full_pipeline(*test_info)
 
     @pytest.mark.skipif(CAN_SLURM is False, reason="CAN_SLURM is false")
-    def test_single_run_slurm(self, test_info, output_data_path):
-        test_info.pop(3)
+    def test_single_run_slurm(self, test_info):
+
+        base_path = test_info[0]
 
         test_info[2] = test_info[2][0]
 
-        self.clear_slurm_logs(output_data_path)
+        self.clear_slurm_logs(base_path)
 
         self.run_full_pipeline(*test_info, slurm_batch={"wait": True})
 
-        self.check_slurm_log(output_data_path)
+        self.check_slurm_log(base_path)
 
-    def check_slurm_log(self, output_data_path):
-        slurm_run = output_data_path.glob("slurm_logs/*/*log.out")
+    @pytest.mark.skipif(CAN_SLURM is False, reason="CAN_SLURM is false")
+    def test_multi_run_slurm(self, test_info):
+
+        base_path = test_info[0]
+
+        self.clear_slurm_logs(base_path)
+
+        self.run_full_pipeline(*test_info, slurm_batch={"wait": True})
+
+        self.check_slurm_log(base_path)
+
+    def check_slurm_log(self, base_path):
+
+        slurm_run = base_path.glob("slurm_logs/*/*log.out")
         slurm_run = list(slurm_run)[0]
 
         with open(slurm_run, "r") as log:
@@ -163,18 +178,8 @@ class TestFirstEphys:
         assert "Quality metrics saved to" in log_output
         assert "Job completed successfully" in log_output
 
-    @pytest.mark.skipif(CAN_SLURM is False, reason="CAN_SLURM is false")
-    def test_multi_run_slurm(self, test_info, output_data_path):
-        test_info.pop(3)
-
-        self.clear_slurm_logs(output_data_path)
-
-        self.run_full_pipeline(*test_info, slurm_batch={"wait": True})
-
-        self.check_slurm_log(output_data_path)
-
-    def clear_slurm_logs(self, output_data_path):
-        slurm_path = output_data_path / "slurm_logs"
+    def clear_slurm_logs(self, base_path):
+        slurm_path = base_path / "slurm_logs"
         [shutil.rmtree(path_) for path_ in slurm_path.glob("*-*-*_*-*-*")]
 
     def test_preprocessing_exists_error(self):
@@ -189,8 +194,15 @@ class TestFirstEphys:
     def test_overwrite_sorter(self):
         raise NotImplementedError
 
+    def test_overwrite_waveforms(self):
+        raise NotImplementedError
+
+    def test_overwrite_postprocessing(self):
+        raise NotImplementedError
+
     def test_sorting_only_local(self):
         raise NotImplementedError
 
     def test_sorting_only_slumr(self):
         raise NotImplementedError
+

--- a/tests/test_integration/test_initial.py
+++ b/tests/test_integration/test_initial.py
@@ -6,7 +6,6 @@ import shutil
 from pathlib import Path
 
 import pytest
-from spikeinterface import concatenate_recordings
 
 from spikewrap.pipeline import full_pipeline, preprocess
 from spikewrap.pipeline.full_pipeline import get_configs
@@ -82,7 +81,9 @@ class TestFirstEphys:
         preprocess_data = load_data(*test_info[:3], data_format="spikeglx")
 
         for run_name in preprocess_data.run_names:
-            preprocess_data = preprocess.preprocess(preprocess_data, run_name, pp_steps, verbose=True)
+            preprocess_data = preprocess.preprocess(
+                preprocess_data, run_name, pp_steps, verbose=True
+            )
 
             preprocess_data.save_preprocessed_data(run_name, overwrite=True)
 
@@ -97,18 +98,20 @@ class TestFirstEphys:
         preprocess_data = load_data(*test_info[:3])
 
         for run_name in preprocess_data.run_names:
-            preprocess_data = preprocess.preprocess(preprocess_data, run_name, pp_steps, verbose=True)
+            preprocess_data = preprocess.preprocess(
+                preprocess_data, run_name, pp_steps, verbose=True
+            )
             preprocess_data.save_preprocessed_data(run_name, overwrite=True)
 
     @pytest.mark.parametrize(
         "sorter",
         [
-            "kilosort2",
-            "kilosort2_5",
-            "kilosort3",
-            "mountainsort5",
-            "spykingcircus2",
-            "tridesclous",
+            #     "kilosort2",
+            #    "kilosort2_5",
+            #   "kilosort3",
+            #  "mountainsort5",
+            "spykingcircus",
+            #  "tridesclous",
         ],
     )
     def test_single_run_local__(self, test_info, sorter):
@@ -120,9 +123,11 @@ class TestFirstEphys:
 
         self.run_full_pipeline(*test_info)
 
-        self.run_full_pipeline(*test_info,
-                               existing_preprocessed_data="overwrite",
-                               existing_sorting_output="overwrite")
+        self.run_full_pipeline(
+            *test_info,
+            existing_preprocessed_data="overwrite",
+            existing_sorting_output="overwrite",
+        )
 
         with pytest.raises(BaseException) as e:
             self.run_full_pipeline(
@@ -134,14 +139,12 @@ class TestFirstEphys:
         )
 
     def test_multi_run_local(self, test_info):
-
         test_info[2] = test_info[2][0]
 
         self.run_full_pipeline(*test_info)
 
     @pytest.mark.skipif(CAN_SLURM is False, reason="CAN_SLURM is false")
     def test_single_run_slurm(self, test_info):
-
         base_path = test_info[0]
 
         test_info[2] = test_info[2][0]
@@ -154,7 +157,6 @@ class TestFirstEphys:
 
     @pytest.mark.skipif(CAN_SLURM is False, reason="CAN_SLURM is false")
     def test_multi_run_slurm(self, test_info):
-
         base_path = test_info[0]
 
         self.clear_slurm_logs(base_path)
@@ -164,7 +166,6 @@ class TestFirstEphys:
         self.check_slurm_log(base_path)
 
     def check_slurm_log(self, base_path):
-
         slurm_run = base_path.glob("slurm_logs/*/*log.out")
         slurm_run = list(slurm_run)[0]
 
@@ -205,4 +206,3 @@ class TestFirstEphys:
 
     def test_sorting_only_slumr(self):
         raise NotImplementedError
-


### PR DESCRIPTION
This PR adds the option to concatenate or not concatenate prior to sorting. This resulted in a large refactoring to allow easy switching between the concatenation vs. non-concatenation case. 

The main changes are that
1) All processing is now handled per-run, which the `Data` classes holding the run name as a dictionary key, they the preprocessing steps. Previously, runs where held as spikeinterface segments. This approach is much more flexible.
2) Complete overhaul of data classes to use getters to get filepaths, names. 
3) Preprocessing is always performed per-run now, and concatenation occurs immediately prior to sorting.

There some outstanding things that currently do not work or are suboptimal
visualising the preprocessing results
issue #84

but merging now in the interest of testing.