### PR TITLE
Print the arguments passed to main public methods

### DIFF
--- a/spikewrap/data_classes/postprocessing.py
+++ b/spikewrap/data_classes/postprocessing.py
@@ -30,8 +30,8 @@ class PostprocessingData:
             self.sorting_info["preprocessing_run_names"],
             self.sorting_info["sorter"],
             self.sorting_info["concat_for_sorting"],
+            print_messages=False,
         )
-        self.sorting_data.load_preprocessed_binary()
 
         self.sorted_run_name = self.sorting_info["sorted_run_name"]
         self.preprocessing_info = self.sorting_info["preprocessing"]

--- a/spikewrap/data_classes/sorting.py
+++ b/spikewrap/data_classes/sorting.py
@@ -55,12 +55,19 @@ class SortingData(BaseUserDict):
     """
 
     def __init__(
-        self, base_path, sub_name, run_names, sorter: str, concat_for_sorting: bool
+        self,
+        base_path,
+        sub_name,
+        run_names,
+        sorter: str,
+        concat_for_sorting: bool,
+        print_messages: bool = True,
     ):
         super(SortingData, self).__init__(base_path, sub_name, run_names)
 
         self.concat_for_sorting = concat_for_sorting
         self.sorter = sorter
+        self.print_messages = print_messages
 
         self._check_preprocessing_exists()
 
@@ -190,20 +197,22 @@ class SortingData(BaseUserDict):
 
         concatenated_recording = concatenate_recordings(recordings_list)
 
-        # Perform some checks before returning.
         assert loaded_prepro_run_names == tuple(
             self.preprocessing_run_names
         ), "Something has gone wrong in the `run_names` ordering."
 
-        if not self._run_names_are_in_datetime_order("creation"):
-            warnings.warn(
-                "The runs provided are not in creation datetime order.\n"
-                "They will be concatenated in the order provided."
-            )
+        if self.print_messages:
+            if not self._run_names_are_in_datetime_order("creation"):
+                warnings.warn(
+                    "The runs provided are not in creation datetime order.\n"
+                    "They will be concatenated in the order provided."
+                )
 
-        utils.message_user(
-            f"Concatenating runs in the order: " f"{loaded_prepro_run_names}"
-        )
+            utils.message_user(
+                f"Preprocessed data loaded prior to sorting. "
+                f"Runs were concatenated runs in the order: "
+                f"{loaded_prepro_run_names}"
+            )
 
         return concatenated_recording
 

--- a/spikewrap/examples/example_full_pipeline.py
+++ b/spikewrap/examples/example_full_pipeline.py
@@ -25,8 +25,8 @@ if __name__ == "__main__":
         config_name,
         sorter,
         concat_for_sorting=True,
-        existing_preprocessed_data="load_if_exists",
-        existing_sorting_output="load_if_exists",
+        existing_preprocessed_data="overwrite",
+        existing_sorting_output="overwrite",
         overwrite_postprocessing=True,
         delete_intermediate_files=(
             "recording.dat",

--- a/spikewrap/pipeline/full_pipeline.py
+++ b/spikewrap/pipeline/full_pipeline.py
@@ -123,6 +123,8 @@ def run_full_pipeline(
         If True, the pipeline will be run in a SLURM job. Set False
         if running on an interactive job, or locally.
     """
+    passed_arguments = locals()
+
     if slurm_batch:
         local_args = copy.deepcopy(locals())
         slurm.run_full_pipeline_slurm(**local_args)
@@ -132,8 +134,10 @@ def run_full_pipeline(
     pp_steps, sorter_options, waveform_options = get_configs(config_name)
 
     logs = logging_sw.get_started_logger(
-        utils.get_logging_path(base_path, sub_name), "full_pipeline"
+        utils.get_logging_path(base_path, sub_name),
+        "full_pipeline",
     )
+    utils.show_passed_arguments(passed_arguments, "`run_full pipeline`")
 
     loaded_data = load_data(base_path, sub_name, run_names, data_format="spikeglx")
 

--- a/spikewrap/pipeline/postprocess.py
+++ b/spikewrap/pipeline/postprocess.py
@@ -84,6 +84,8 @@ def run_postprocess(
         A dictionary containing options passed to SpikeInterface's
         `extract_waveforms()` function as kwargs.
     """
+    passed_arguments = locals()
+
     postprocess_data = PostprocessingData(sorting_path)
 
     logs = logging_sw.get_started_logger(
@@ -91,8 +93,9 @@ def run_postprocess(
             postprocess_data.sorting_info["base_path"],
             postprocess_data.sorting_info["sub_name"],
         ),
-        "full_pipeline",
+        "postprocess",
     )
+    utils.show_passed_arguments(passed_arguments, "`run_postprocess`")
 
     utils.message_user(f"Postprocessing run: {postprocess_data.sorted_run_name}...")
 

--- a/spikewrap/pipeline/sort.py
+++ b/spikewrap/pipeline/sort.py
@@ -82,9 +82,12 @@ def run_sorting(
         if running on an interactive job, or locally.
 
     """
+    passed_arguments = locals()
     logs = logging_sw.get_started_logger(
-        utils.get_logging_path(base_path, sub_name), "full_pipeline"
+        utils.get_logging_path(base_path, sub_name),
+        "sorting",
     )
+    utils.show_passed_arguments(passed_arguments, "`run_sorting`")
 
     sorting_data = SortingData(
         base_path,

--- a/spikewrap/utils/logging_sw.py
+++ b/spikewrap/utils/logging_sw.py
@@ -171,15 +171,18 @@ class StreamToLogger(object):
 
 def get_started_logger(
     log_filepath: Path,
-    run_name: Literal["full_pipeline", "preprocess", "sorting", "postprocess"],
+    run_name: Literal["full_pipeline", "sorting", "postprocess"],
 ) -> HandleLogging:
     """
     Convenience function that creates logger name and stars a
-    HandleLogging() instance.
+    HandleLogging() instance. Note that this may be called
+    even when the logging does not log, see HandleLogging()
+    docs for details.
     """
     format_datetime = utils.get_formatted_datetime()
     log_name = f"{format_datetime}_{run_name}.log"
 
     logs = HandleLogging()
     logs.start_logging(log_filepath / log_name)
+
     return logs

--- a/spikewrap/utils/utils.py
+++ b/spikewrap/utils/utils.py
@@ -69,6 +69,13 @@ def get_logging_path(base_path: Union[str, Path], sub_name: str) -> Path:
     return Path(base_path) / "derivatives" / sub_name / "logs"
 
 
+def show_passed_arguments(passed_arguments, function_name):
+    message_user(
+        f"Running {function_name}. The function was called "
+        f"with the arguments {passed_arguments}.",
+    )
+
+
 def message_user(message: str, verbose: bool = True) -> None:
     """
     Method to interact with user.


### PR DESCRIPTION
Add to logs all the args / kwargs the main functions (`run_full_pipeline`, `run_sorting`, `run_postprocess` are called with). Also, add a `print_statements` bool to `SortingData` as things were been logged at incorreect time when this class was reinstantiated during PostprocessData setup.