### PR TITLE
Ensure custom types are used where relevant for long string Literals.

### DIFF
--- a/spikewrap/pipeline/full_pipeline.py
+++ b/spikewrap/pipeline/full_pipeline.py
@@ -69,7 +69,7 @@ def run_full_pipeline(
         If `True`, preprocessed runs are concatenated before sorting. Otherwise,
         sorting is performed per-run.
 
-    existing_preprocessed_data : Literal["overwrite", "load_if_exists", "fail_if_exists"]
+    existing_preprocessed_data : custom_types.HandleExisting
         Determines how existing preprocessed data (e.g. from a prior pipeline run)
         is handled.
             "overwrite" : will overwrite any existing preprocessed data output. This will
@@ -182,9 +182,7 @@ def run_full_pipeline(
 def preprocess_and_save(
     preprocess_data: PreprocessingData,
     pp_steps,
-    existing_preprocessed_data: Literal[
-        "overwrite", "load_if_exists", "fail_if_exists"
-    ],
+    existing_preprocessed_data: HandleExisting,
     verbose,
 ) -> None:
     """

--- a/spikewrap/pipeline/postprocess.py
+++ b/spikewrap/pipeline/postprocess.py
@@ -43,7 +43,7 @@ def run_postprocess(
         If `True`, existing postprocessing is deleted in it's entirely. Otherwise
         if `False` and postprocesing already exists, an error will be raised.
 
-    existing_waveform_data : Literal["overwrite", "load_if_exists", "fail_if_exists"]
+    existing_waveform_data : custom_types.HandleExisting
         Determines how existing preprocessed data (e.g. from a prior pipeline run)
         is treated.
             "overwrite" : will overwrite any existing preprocessed data output. This will

--- a/spikewrap/pipeline/sort.py
+++ b/spikewrap/pipeline/sort.py
@@ -61,7 +61,7 @@ def run_sorting(
     sorter_options : Dict
         Kwargs to pass to spikeinterface sorter class.
 
-    existing_sorting_output : Literal["overwrite", "load_if_exists", "fail_if_exists"]
+    existing_sorting_output : custom_types.HandleExisting
         Determines how existing sorting output (e.g. from a prior pipeline run)
         is handled.
             "overwrite" : will overwrite any existing preprocessed data output. This will


### PR DESCRIPTION
closes #61. See custom_types.py. This PR ensures consistent use, custom_types.py was incremenetally added over the last few PRs.