### PR TITLE
Remove verbose option.

### DIFF
--- a/spikewrap/examples/example_preprocess.py
+++ b/spikewrap/examples/example_preprocess.py
@@ -28,7 +28,7 @@ for ses_name in sessions_and_runs.keys():
         t = time.time()
 
         preprocess_data = preprocess(
-            loaded_data, ses_name, run_name, pp_steps="default", verbose=True
+            loaded_data, ses_name, run_name, pp_steps="default"
         )
         preprocess_data.save_preprocessed_data(ses_name, run_name, overwrite=True)
 

--- a/spikewrap/pipeline/full_pipeline.py
+++ b/spikewrap/pipeline/full_pipeline.py
@@ -231,9 +231,7 @@ def preprocess_and_save(
                 "Must be: 'load_if_exists', 'fail_if_exists' or 'overwrite'."
             )
 
-        preprocess_data = preprocess(
-            preprocess_data, ses_name, run_name, pp_steps
-        )
+        preprocess_data = preprocess(preprocess_data, ses_name, run_name, pp_steps)
         preprocess_data.save_preprocessed_data(ses_name, run_name, overwrite)
 
 

--- a/spikewrap/pipeline/full_pipeline.py
+++ b/spikewrap/pipeline/full_pipeline.py
@@ -28,7 +28,6 @@ def run_full_pipeline(
     overwrite_postprocessing: bool = False,
     postprocessing_to_run: Union[Literal["all"], Dict] = "all",
     delete_intermediate_files: DeleteIntermediate = ("recording.dat",),
-    verbose: bool = True,
     slurm_batch: bool = False,
 ) -> Tuple[Optional[PreprocessingData], Optional[SortingData]]:
     """
@@ -113,10 +112,6 @@ def run_full_pipeline(
                     quality metrics. Often, these can be deleted once final quality
                     metrics are computed.
 
-    verbose : bool
-        If True, messages will be printed to console updating on the
-        progress of preprocessing / sorting.
-
     slurm_batch : bool
         If True, the pipeline will be run in a SLURM job. Set False
         if running on an interactive job, or locally.
@@ -140,7 +135,7 @@ def run_full_pipeline(
         base_path, sub_name, sessions_and_runs, data_format="spikeglx"
     )
 
-    preprocess_and_save(loaded_data, pp_steps, existing_preprocessed_data, verbose)
+    preprocess_and_save(loaded_data, pp_steps, existing_preprocessed_data)
 
     sorting_data = run_sorting(
         base_path,
@@ -151,7 +146,6 @@ def run_full_pipeline(
         concat_runs_for_sorting,
         sorter_options,
         existing_sorting_output,
-        verbose,
     )
     assert sorting_data is not None
 
@@ -164,7 +158,6 @@ def run_full_pipeline(
             overwrite_postprocessing=overwrite_postprocessing,
             existing_waveform_data="fail_if_exists",
             postprocessing_to_run=postprocessing_to_run,
-            verbose=verbose,
             waveform_options=waveform_options,
         )
 
@@ -190,7 +183,6 @@ def preprocess_and_save(
     preprocess_data: PreprocessingData,
     pp_steps,
     existing_preprocessed_data: HandleExisting,
-    verbose: bool,
 ) -> None:
     """
     Handle the loading of existing preprocessed data.
@@ -240,7 +232,7 @@ def preprocess_and_save(
             )
 
         preprocess_data = preprocess(
-            preprocess_data, ses_name, run_name, pp_steps, verbose
+            preprocess_data, ses_name, run_name, pp_steps
         )
         preprocess_data.save_preprocessed_data(ses_name, run_name, overwrite)
 

--- a/spikewrap/pipeline/postprocess.py
+++ b/spikewrap/pipeline/postprocess.py
@@ -25,7 +25,6 @@ def run_postprocess(
     overwrite_postprocessing: bool = False,
     existing_waveform_data: HandleExisting = "fail_if_exists",
     postprocessing_to_run: Union[Literal["all"], Dict] = "all",
-    verbose: bool = True,
     waveform_options: Optional[Dict] = None,
 ) -> PostprocessingData:
     """
@@ -61,10 +60,6 @@ def run_postprocess(
         including postprocessing to run e.g. {"quality_metrics: True"}.
         Accepted keys are "quality_metrics" and "unit_locations".
 
-    verbose : bool
-        If True, messages will be printed to console updating on the
-        progress of preprocessing / sorting.
-
     waveform_options: Dict
         A dictionary containing options passed to SpikeInterface's
         `extract_waveforms()` function as kwargs.
@@ -94,7 +89,7 @@ def run_postprocess(
         _, _, waveform_options = get_configs("default")
 
     waveforms = run_or_get_waveforms(
-        postprocess_data, existing_waveform_data, waveform_options, verbose
+        postprocess_data, existing_waveform_data, waveform_options
     )
 
     # Perform postprocessing
@@ -127,7 +122,6 @@ def run_or_get_waveforms(
     postprocess_data: PostprocessingData,
     existing_waveform_data: HandleExisting,
     waveform_options: Dict,
-    verbose: bool,
 ) -> WaveformExtractor:
     """
     How to handle existing waveform output, either load, fail if exists or
@@ -138,7 +132,6 @@ def run_or_get_waveforms(
     if postprocessing_path.is_dir() and existing_waveform_data == "load_if_exists":
         utils.message_user(
             f"Loading existing waveforms from: " f"{postprocessing_path}",
-            verbose,
         )
         waveforms = si.load_waveforms(postprocessing_path)
 

--- a/spikewrap/pipeline/preprocess.py
+++ b/spikewrap/pipeline/preprocess.py
@@ -14,7 +14,6 @@ def preprocess(
     ses_name: str,
     run_name: str,
     pp_steps: Union[Dict, str],
-    verbose: bool = True,
 ) -> PreprocessingData:
     """
     Returns an updated PreprocessingData dictionary of SpikeInterface
@@ -39,10 +38,6 @@ def preprocess(
     pp_steps: either a pp_steps dictionary, or name of valid
               preprocessing .yaml file (without hte yaml extension).
               See configs/configs.py for details.
-
-    verbose : bool
-        If True, messages will be printed to console updating on the
-        progress of preprocessing / sorting.
 
     Returns
     -------
@@ -73,7 +68,6 @@ def preprocess(
             run_name,
             pp_step_names,
             pp_funcs,
-            verbose,
         )
 
     return preprocess_data
@@ -157,7 +151,6 @@ def perform_preprocessing_step(
     run_name: str,
     pp_step_names: List[str],
     pp_funcs: Dict,
-    verbose: bool = True,
 ) -> None:
     """
     Given the preprocessing step and preprocess_data UserDict containing
@@ -191,15 +184,11 @@ def perform_preprocessing_step(
     pp_funcs : Dict
         The canonical SpikeInterface preprocessing functions. The key
         are the function name and value the function object.
-
-    verbose : bool
-        If True, messages will be printed to console updating on the
-        progress of preprocessing / sorting.
     """
     pp_name, pp_options = pp_info
 
     utils.message_user(
-        f"Running preprocessing step: {pp_name} with options {pp_options}", verbose
+        f"Running preprocessing step: {pp_name} with options {pp_options}"
     )
 
     last_pp_step_output, __ = utils.get_dict_value_from_step_num(

--- a/spikewrap/pipeline/sort.py
+++ b/spikewrap/pipeline/sort.py
@@ -29,7 +29,6 @@ def run_sorting(
     concatenate_runs: bool = False,
     sorter_options: Optional[Dict] = None,
     existing_sorting_output: HandleExisting = "fail_if_exists",
-    verbose: bool = True,
     slurm_batch: bool = False,
 ) -> Optional[SortingData]:
     """
@@ -79,10 +78,6 @@ def run_sorting(
             "fail_if_exists" : If existing preprocessed data is found, an error
                                will be raised.
 
-    verbose : bool
-        If True, messages will be printed to console updating on the
-        progress of preprocessing / sorting.
-
     slurm_batch : bool
         If True, the pipeline will be run in a SLURM job. Set False
         if running on an interactive job, or locally.
@@ -107,7 +102,7 @@ def run_sorting(
         Path(base_path), sub_name, sessions_and_runs, sorter
     )
 
-    sorter_options_dict = validate_inputs(slurm_batch, sorter, sorter_options, verbose)
+    sorter_options_dict = validate_inputs(slurm_batch, sorter, sorter_options)
 
     # This must be run from the folder that has both sorter output AND rawdata
     os.chdir(sorting_data.base_path)
@@ -231,7 +226,7 @@ def run_sorting_on_all_runs(
 
 
 def validate_inputs(
-    slurm_batch: bool, sorter: str, sorter_options: Optional[Dict], verbose: bool
+    slurm_batch: bool, sorter: str, sorter_options: Optional[Dict]
 ) -> Dict:
     """
     Check that the sorter is valid, singularity is installed and format
@@ -250,9 +245,6 @@ def validate_inputs(
     sorter_options : Optional[Dict]
         Options to pass to the SpikeInterface sorter. If None, no options
         are passed.
-
-    verbose : bool
-        Whether SpikeInterface sorting is run in 'verbose' mode.
 
     Returns
     -------
@@ -279,7 +271,7 @@ def validate_inputs(
     if sorter_options is not None and sorter in sorter_options:
         sorter_options_dict = sorter_options[sorter]
 
-    sorter_options_dict.update({"verbose": verbose})
+    sorter_options_dict.update({"verbose": True})
 
     return sorter_options_dict
 

--- a/spikewrap/utils/utils.py
+++ b/spikewrap/utils/utils.py
@@ -78,7 +78,7 @@ def show_passed_arguments(passed_arguments, function_name):
     )
 
 
-def message_user(message: str, verbose: bool = True) -> None:
+def message_user(message: str) -> None:
     """
     Method to interact with user.
 
@@ -86,13 +86,8 @@ def message_user(message: str, verbose: bool = True) -> None:
     ----------
     message : str
         Message to print.
-
-    verbose : bool
-        The mode of the application. If verbose is False,
-        nothing is printed.
     """
-    if verbose:
-        print(f"\n{message}")
+    print(f"\n{message}")
 
 
 def dump_dict_to_yaml(filepath: Union[Path, str], dict_: Dict) -> None:


### PR DESCRIPTION
Remove the `verbose` option as it was pointless / inconsistently used.