### PR TITLE
Remove postprocessing to run.

### DIFF
--- a/spikewrap/examples/example_postprocess.py
+++ b/spikewrap/examples/example_postprocess.py
@@ -21,5 +21,4 @@ sorting_path = (
 run_postprocess(
     sorting_path,
     existing_waveform_data="overwrite",
-    postprocessing_to_run="all",
 )

--- a/spikewrap/pipeline/full_pipeline.py
+++ b/spikewrap/pipeline/full_pipeline.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import shutil
 from pathlib import Path
-from typing import Dict, Literal, Optional, Tuple, Union
+from typing import Dict, Optional, Tuple, Union
 
 from ..configs.configs import get_configs
 from ..data_classes.preprocessing import PreprocessingData
@@ -26,7 +26,6 @@ def run_full_pipeline(
     existing_preprocessed_data: HandleExisting = "fail_if_exists",
     existing_sorting_output: HandleExisting = "fail_if_exists",
     overwrite_postprocessing: bool = False,
-    postprocessing_to_run: Union[Literal["all"], Dict] = "all",
     delete_intermediate_files: DeleteIntermediate = ("recording.dat",),
     slurm_batch: bool = False,
 ) -> Tuple[Optional[PreprocessingData], Optional[SortingData]]:
@@ -90,12 +89,6 @@ def run_full_pipeline(
         that the entire 'postprocessing' folder (including all contents) will be
         deleted. Therefore, never save derivative work there.
 
-    postprocessing_to_run : Union[Literal["all"], Dict]
-        Specify the postprocessing to run. By default, "all" will run
-        all available postprocessing. Otherwise, provide a dict of
-        including postprocessing to run e.g. {"quality_metrics: True"}.
-        Accepted keys are "quality_metrics" and "unit_locations".
-
     delete_intermediate_files : DeleteIntermediate
         Specify intermediate files or folders to delete. This option is useful for
         reducing the size of output data by deleting unneeded files.
@@ -157,7 +150,6 @@ def run_full_pipeline(
             sorting_path,
             overwrite_postprocessing=overwrite_postprocessing,
             existing_waveform_data="fail_if_exists",
-            postprocessing_to_run=postprocessing_to_run,
             waveform_options=waveform_options,
         )
 

--- a/spikewrap/pipeline/postprocess.py
+++ b/spikewrap/pipeline/postprocess.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import shutil
 from pathlib import Path
-from typing import TYPE_CHECKING, Dict, Literal, Optional, Union
+from typing import TYPE_CHECKING, Dict, Optional, Union
 
 import pandas as pd
 import spikeinterface as si
@@ -24,7 +24,6 @@ def run_postprocess(
     sorting_path: Union[Path, str],
     overwrite_postprocessing: bool = False,
     existing_waveform_data: HandleExisting = "fail_if_exists",
-    postprocessing_to_run: Union[Literal["all"], Dict] = "all",
     waveform_options: Optional[Dict] = None,
 ) -> PostprocessingData:
     """
@@ -50,12 +49,6 @@ def run_postprocess(
                                current run.
             "fail_if_exists" : If existing preprocessed data is found, an error
                                will be raised.
-
-    postprocessing_to_run : Union[Literal["all"], Dict]
-        Specify the postprocessing to run. By default, "all" will run
-        all available postprocessing. Otherwise, provide a dict of
-        including postprocessing to run e.g. {"quality_metrics: True"}.
-        Accepted keys are "quality_metrics" and "unit_locations".
 
     waveform_options: Dict
         A dictionary containing options passed to SpikeInterface's
@@ -90,13 +83,9 @@ def run_postprocess(
     )
 
     # Perform postprocessing
-    run_settings = handle_postprocessing_to_run(postprocessing_to_run)
+    save_quality_metrics(waveforms, postprocess_data.get_quality_metrics_path())
 
-    if run_option(run_settings, "quality_metrics"):
-        save_quality_metrics(waveforms, postprocess_data.get_quality_metrics_path())
-
-    if run_option(run_settings, "unit_locations"):
-        save_unit_locations(waveforms, postprocess_data.get_unit_locations_path())
+    save_unit_locations(waveforms, postprocess_data.get_unit_locations_path())
 
     logs.stop_logging()
 
@@ -104,15 +93,6 @@ def run_postprocess(
 
 
 # Sorting Loader -----------------------------------------------------------------------
-
-
-def run_option(run_settings: Dict, option: str) -> bool:
-    """
-    When to run the option that may either not be in the dict
-    (do not run) or is in the dict and set `False`.
-    TODO: just use a Tuple instead.
-    """
-    return option in run_settings and run_settings[option]
 
 
 def run_or_get_waveforms(
@@ -150,37 +130,6 @@ def run_or_get_waveforms(
         )
 
     return waveforms
-
-
-def handle_postprocessing_to_run(
-    postprocessing_to_run: Union[Literal["all"], Dict]
-) -> Dict:
-    """
-    Set to run all postprocessing steps. If user-dict is provided,
-    ensure it contains expected keys / values.
-    """
-    run_settings = {
-        "quality_metrics": True,
-        "unit_locations": True,
-    }
-
-    if postprocessing_to_run == "all":
-        return run_settings
-    else:
-        assert isinstance(postprocessing_to_run, Dict)
-        assert all(
-            [key in run_settings.keys() for key in postprocessing_to_run.keys()]
-        ), (
-            f"At least one option in `postprocessing_to_run` is invalid. Must be"
-            f"one of {run_settings.keys()}"
-        )
-        assert all(
-            [isinstance(value, bool) for value in postprocessing_to_run.values()]
-        ), "`postprocessing_to_run` values must be `True` or `False`."
-
-        run_settings = postprocessing_to_run
-
-        return run_settings
 
 
 def handle_delete_existing_postprocessing(


### PR DESCRIPTION
Remove the `postprocessing_to_run` option as currently there are only two postprocessing that can be run `quality_checks` and `unit_locations`. This setting was vestigal from when other postprocessing options were removed in #85 

