### PR TITLE
Add default HPC configs and SLURM batch settings.

### DIFF
--- a/spikewrap/configs/backend/hpc.py
+++ b/spikewrap/configs/backend/hpc.py
@@ -1,0 +1,37 @@
+"""
+Here defaults related to the HPC system `spikewrap` is run on
+(if not running locally) are stored.
+
+
+`hpc_sorter_images_path()`
+    This function returns the default path where singularity images are stored.
+    The purpose of this storage path is to avoid users installing multiple copies
+    across the system. This path can be changed based on the HPC system used and
+    populated with SpikeInterface singularity images.
+
+`default_slurm_options()`
+    The default options passed to the submitit executor and converted
+    to SLURM batch script arguments. If passing new options in `slurm_batch`,
+    the passed options are overriden but other defaults are maintained.
+"""
+from typing import Dict
+
+
+def hpc_sorter_images_path() -> str:
+    return "/ceph/neuroinformatics/neuroinformatics/scratch/sorter_images"
+
+
+def default_slurm_options() -> Dict:
+    return {
+        "nodes": 1,
+        "mem_gb": 40,
+        "timeout_min": 24 * 60,
+        "cpus_per_task": 8,
+        "tasks_per_node": 1,
+        "gpus_per_node": 1,
+        "slurm_gres": "gpu:1",
+        "slurm_partition": "gpu",
+        "exclude": "gpu-sr670-20,gpu-sr670-21,gpu-sr670-22",
+        "wait": False,
+        "env_name": "spikewrap",
+    }

--- a/spikewrap/pipeline/full_pipeline.py
+++ b/spikewrap/pipeline/full_pipeline.py
@@ -27,7 +27,7 @@ def run_full_pipeline(
     existing_sorting_output: HandleExisting = "fail_if_exists",
     overwrite_postprocessing: bool = False,
     delete_intermediate_files: DeleteIntermediate = ("recording.dat",),
-    slurm_batch: bool = False,
+    slurm_batch: Union[bool, Dict] = False,
 ) -> Tuple[Optional[PreprocessingData], Optional[SortingData]]:
     """
     Run preprocessing, sorting and post-processing on SpikeGLX data.
@@ -113,9 +113,19 @@ def run_full_pipeline(
                     quality metrics. Often, these can be deleted once final quality
                     metrics are computed.
 
-    slurm_batch : bool
+    slurm_batch : Union[bool, Dict]
         If True, the pipeline will be run in a SLURM job. Set False
-        if running on an interactive job, or locally.
+        if running on an interactive job, or locally. By default,
+        slurm is run with the option set in configs/backend/hpc.py.
+        To overwrite, pass a dict of submitit key-value pairs to
+        overwrite the default options. Note that only the passed
+        options will be overwritten, all other defaults will be
+        maintained if not explicitly overwritten.
+
+        Importantly, if the environment you are running the slurm job
+        in is not called `spikewrap`, you will need to pass the name of the
+        conda environment you want to run the job in, as an option
+        in the dictionary e.g. `slurm_batch={"env_name": "my_env_name"}`.
     """
     passed_arguments = locals()
     validate.check_function_arguments(passed_arguments)

--- a/spikewrap/pipeline/preprocess.py
+++ b/spikewrap/pipeline/preprocess.py
@@ -14,7 +14,7 @@ def run_preprocess(
     preprocess_data: PreprocessingData,
     pp_steps: Union[Dict, str],
     save_to_file: Union[Literal[False], HandleExisting],
-    slurm_batch: bool = False,
+    slurm_batch: Union[bool, Dict] = False,
     log: bool = True,
 ) -> None:
     """

--- a/spikewrap/pipeline/sort.py
+++ b/spikewrap/pipeline/sort.py
@@ -29,7 +29,7 @@ def run_sorting(
     concatenate_runs: bool = False,
     sorter_options: Optional[Dict] = None,
     existing_sorting_output: HandleExisting = "fail_if_exists",
-    slurm_batch: bool = False,
+    slurm_batch: Union[bool, Dict] = False,
 ) -> Optional[SortingData]:
     """
     Run a sorter on pre-processed data. Takes a PreprocessingData (pipeline.data_class)
@@ -86,9 +86,19 @@ def run_sorting(
             "fail_if_exists" : If existing sorting output is found, an error
                                will be raised.
 
-    slurm_batch : bool
+    slurm_batch : Union[bool, Dict]
         If True, the pipeline will be run in a SLURM job. Set False
-        if running on an interactive job, or locally.
+        if running on an interactive job, or locally. By default,
+        slurm is run with the option set in configs/backend/hpc.py.
+        To overwrite, pass a dict of submitit key-value pairs to
+        overwrite the default options. Note that only the passed
+        options will be overwritten, all other defaults will be
+        maintained if not explicitly overwritten.
+
+        Importantly, if the environment you are running the slurm job
+        in is not called `spikewrap`, you will need to pass the name of the
+        conda environment you want to run the job in, as an option
+        in the dictionary e.g. `slurm_batch={"env_name": "my_env_name"}`.
 
     """
     passed_arguments = locals()

--- a/spikewrap/utils/managing_images.py
+++ b/spikewrap/utils/managing_images.py
@@ -5,6 +5,7 @@ import shutil
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal, Optional, Tuple, Union
 
+from ..configs.backend.hpc import hpc_sorter_images_path
 from . import checks
 
 if TYPE_CHECKING:
@@ -170,7 +171,7 @@ def get_hpc_sorter_path(sorter: str) -> Path:
     sorter_path : Path
         The base to the sorter image on SWC HCP (ceph).
     """
-    base_path = Path("/ceph/neuroinformatics/neuroinformatics/scratch/sorter_images")
+    base_path = Path(hpc_sorter_images_path())
     sorter_path = base_path / sorter / get_sorter_image_name(sorter)
     return sorter_path
 

--- a/spikewrap/utils/validate.py
+++ b/spikewrap/utils/validate.py
@@ -4,6 +4,7 @@ from typing import Dict, List, Optional
 import typeguard
 from typeguard import CollectionCheckStrategy
 
+from ..configs.backend.hpc import default_slurm_options
 from ..data_classes.preprocessing import PreprocessingData
 from ..utils.custom_types import DeleteIntermediate, HandleExisting
 
@@ -106,6 +107,14 @@ def check_function_arguments(arguments):
                 raise TypeError(
                     "`slurm_batch` must be `True` or a Dict of slurm settings."
                 )
+
+            if typecheck(arg_value, Dict):
+                for key in arg_value.keys():
+                    if key not in default_slurm_options():
+                        raise ValueError(
+                            f"The `slurm batch key {key} is incorrect. "
+                            f"Must be one of {default_slurm_options()}"
+                        )
 
         # Preprocessing ----------------------------------------------------------------
 

--- a/tests/test_integration/test_validate.py
+++ b/tests/test_integration/test_validate.py
@@ -155,11 +155,13 @@ class TestValidate(BaseTest):
             e.value
         )
 
-        # TODO: ADD
-        #        slurm_batch = {"bad_option": False}
-        #        with pytest.raises(ValueError) as e:
-        #            self.run_full_pipeline(*test_info, slurm_batch=slurm_batch)  #
-        #            TODO: check all naming.
+        slurm_batch = {"gpus_per_node_x": 1}
+        with pytest.raises(ValueError) as e:
+            self.run_full_pipeline(*test_info, slurm_batch=slurm_batch)
+        assert (
+            "The `slurm batch key gpus_per_node_x is incorrect. "
+            "Must be one of" in str(e.value)
+        )
 
     def test_validate_run_preprocess(self, test_info):
         self.remove_all_except_first_run_and_sessions(test_info)


### PR DESCRIPTION
Expose HPC-related configs that may change when using on a different HPC system, as well as the default SLURM options.

The only real config to expose for HPC settings is the path where all sorter images are stored. See #99 for more required work on this front.

Similarly, expose the default slurm options and allow user-overwrites.. Everything is exposed in `/configs/backend/hpc.py`