### PR TITLE
Fix typing on `session_and_runs`.

### DIFF
--- a/spikewrap/data_classes/base.py
+++ b/spikewrap/data_classes/base.py
@@ -24,7 +24,7 @@ class BaseUserDict(UserDict):
 
     base_path: Path
     sub_name: str
-    sessions_and_runs: Dict
+    sessions_and_runs: Dict[str, List[str]]
 
     def __post_init__(self) -> None:
         self.data: Dict = {}
@@ -32,7 +32,15 @@ class BaseUserDict(UserDict):
         self.check_run_names_are_formatted_as_list()
 
     def check_run_names_are_formatted_as_list(self) -> None:
-        """"""
+        """
+        `sessions_and_runs` is typed as `Dict[str, List[str]]` but the
+        class will accept `Dict[str, Union[str, List[str]]]` and
+        cast here. Attempted to type with the latter, or `
+        MutableMapping[str, [str, Union[str, List[str]]]` but had many issues
+        such as https://github.com/python/mypy/issues/8136. The main thing
+        is we can work with `Dict[str, List[str]]` but if `Dict[str, str]` is
+        passed n general use it will not fail.
+        """
         for key, value in self.sessions_and_runs.items():
             if not isinstance(value, List):
                 assert isinstance(

--- a/spikewrap/examples/example_full_pipeline.py
+++ b/spikewrap/examples/example_full_pipeline.py
@@ -36,7 +36,7 @@ if __name__ == "__main__":
     run_full_pipeline(
         base_path,
         sub_name,
-        sessions_and_runs,  # type: ignore # currently asking on mypy's Gitter
+        sessions_and_runs,
         config_name,
         sorter,
         concat_sessions_for_sorting=True,  # TODO: validate this at the start, in `run_full_pipeline`

--- a/spikewrap/examples/example_sort.py
+++ b/spikewrap/examples/example_sort.py
@@ -7,7 +7,7 @@ base_path = Path(
 )
 sub_name = "sub-1119617"
 sessions_and_runs = {
-    "ses-001": "run-001_1119617_LSE1_shank12_g0",
+    "ses-001": ["run-001_1119617_LSE1_shank12_g0"],
 }
 
 

--- a/spikewrap/pipeline/full_pipeline.py
+++ b/spikewrap/pipeline/full_pipeline.py
@@ -18,7 +18,7 @@ from .sort import run_sorting
 def run_full_pipeline(
     base_path: Union[Path, str],
     sub_name: str,
-    sessions_and_runs: Dict[str, Union[str, List[str]]],
+    sessions_and_runs: Dict[str, List[str]],
     config_name: str = "default",
     sorter: str = "kilosort2_5",
     concat_sessions_for_sorting: bool = False,

--- a/spikewrap/pipeline/load_data.py
+++ b/spikewrap/pipeline/load_data.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Dict, Union
+from typing import Dict, List, Union
 
 import spikeinterface.extractors as se
 
@@ -12,7 +12,7 @@ from ..utils import utils
 def load_data(
     base_path: Union[Path, str],
     sub_name: str,
-    sessions_and_runs: Dict,
+    sessions_and_runs: Dict[str, List[str]],
     data_format: str = "spikeglx",
 ) -> PreprocessingData:
     """

--- a/spikewrap/pipeline/sort.py
+++ b/spikewrap/pipeline/sort.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
-from typing import Dict, Literal, Optional, Union
+from typing import Dict, List, Literal, Optional, Union
 
 import spikeinterface.sorters as ss
 
@@ -23,7 +23,7 @@ from ..utils.managing_images import (
 def run_sorting(
     base_path: Union[str, Path],
     sub_name: str,
-    sessions_and_runs: Dict,
+    sessions_and_runs: Dict[str, List[str]],
     sorter: str,
     concatenate_sessions: bool = False,
     concatenate_runs: bool = False,

--- a/spikewrap/pipeline/visualise.py
+++ b/spikewrap/pipeline/visualise.py
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
 
 def visualise(
     data: Union[PreprocessingData, SortingData],
-    sessions_and_runs: Dict,
+    sessions_and_runs: Dict[str, List[str]],
     steps: Union[List[str], str] = "all",
     mode: str = "auto",
     as_subplot: bool = False,


### PR DESCRIPTION
`sessions_and_runs` is really a `Dict[str, Union[str, List[str]]]` but typing it is difficult. See:




However, `Mapping` does not allow item assigment, so `MultableMapping` must be used. But, then I was running into 
[this issue](https://github.com/python/mypy/issues/8136).

As a workaround, I have typed everything to `Dict[str, List[str]]` which is what it should be. The type `Dict[str, Union[str, List[str]]]` was in case user-input a string we do not want to crash. However,  `Dict[str, Union[str, List[str]]]`  is now cast to `Dict[str, Union[str, List[str]]` to be safe but all calls made in the package are `Dict[str, List[str]]` .


Discussed further here:

```
dmr
JoeZiminski (Joe Ziminski)
Thanks for providing such a great support system. Could somone explain the below behaviour (that mypy is failing when the dictionary is passed as a variable, but not passed directly). Is this a bug or am I missing something? thanks!

from typing import Dict, List, Union

def func(a: Dict[str, Union[str, List[str]]]) -> None:
    pass

passed_as_var = {"test_1": ["list_str"]}
func(passed_as_var)
# error: Argument 1 to "func" has incompatible type "dict[str, list[str]]"; expected "dict[str, str | list[str]]"  [arg-type]
# note: "Dict" is invariant -- see https://mypy.readthedocs.io/en/stable/common_issues.html#variance
# note: Consider using "Mapping" instead, which is covariant in the value type
# Found 1 error in 1 file (checked 1 source file)

func({"test_2": ["list_str"]})
# passes
I think what's happened here is

mypy has deduced that the type of passed_as_var is Dict[str, List[str]]. You can check this using reveal_type.
For all it knows, func might modify a so that its values become str instead of List[str].
Doing so would break the type deduced in (1), which would be bad.
I think mypy should be happy if you change either a: Mapping[str, Union[str, List[str]]] or if you annotate passed_as_var: Dict[str, Union[str, List[str]]]. (Disclaimer: untested!) My vote would be for the former.
JoeZiminski (Joe Ziminski)
Message deleted
JoeZiminski (Joe Ziminski)
Thanks dmr! that makes sense and the suggestions resolve the problem. Indeed reveal_type shows passed_as_var as Dict[str, List[str]]. I am trying to wrap my head around invariance, covariance, contravariance. In this case, is it because List[str] is a subtype of Union[str, List[str]]. 'Dict' values are invariant and so will not accept a subtype, while Mapping is covariant so will accept this subtype?
Today
TeamSpen210 (Spencer Brown)
Yes, that is correct.
```