### PR TITLE
Add key imports to `__init__`.

### DIFF
--- a/spikewrap/__init__.py
+++ b/spikewrap/__init__.py
@@ -5,3 +5,20 @@ try:
 except PackageNotFoundError:
     # package is not installed
     pass
+
+from .pipeline.full_pipeline import run_full_pipeline
+from .pipeline.preprocess import run_preprocess
+from .pipeline.sort import run_sorting
+from .pipeline.postprocess import run_postprocess
+
+from .utils.checks import check_environment
+from .utils.slurm import run_interactive_slurm
+
+__all__ = [
+    "run_full_pipeline",
+    "run_preprocess",
+    "run_sorting",
+    "run_postprocess",
+    "check_environment",
+    "run_interactive_slurm",
+]


### PR DESCRIPTION
Move the main public functions to `__init__` so they can be imported directly from the package.

This is taking a long time to import, I am not 100% sure why but may be related to `pip install -e .` method of installation. If this continues to be a problem after `pip` release it will be immediately apparent.