### PR TITLE
Add `write_binary_file` options and handle the percentage case..

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
     "PyYAML",
     "toml",
     "typeguard",
+    "psutil",
     # sorter-specific
     "tridesclous",
     # "spyking-circus", TODO: this is not straightforward, requires mpi4py. TBD if we want to manage this.

--- a/spikewrap/configs/configs.py
+++ b/spikewrap/configs/configs.py
@@ -8,7 +8,7 @@ import yaml
 from spikewrap.utils import utils
 
 
-def get_configs(name: str) -> Tuple[Dict, Dict, Dict]:
+def get_configs(name: str) -> Tuple[Dict, Dict, Dict, Dict]:
     """
     Loads the config yaml file in the same folder
     (spikewrap/configs) containing preprocessing (pp)
@@ -64,7 +64,10 @@ def get_configs(name: str) -> Tuple[Dict, Dict, Dict]:
     pp_steps = config["preprocessing"] if "preprocessing" in config else {}
     sorter_options = config["sorting"] if "sorting" in config else {}
     waveform_options = config["waveforms"] if "waveforms" in config else {}
+    write_binary_options = (
+        config["write_binary_options"] if "write_binary_options" in config else {}
+    )
 
     utils.cast_pp_steps_values(pp_steps, "tuple")
 
-    return pp_steps, sorter_options, waveform_options
+    return pp_steps, sorter_options, waveform_options, write_binary_options

--- a/spikewrap/configs/default.yaml
+++ b/spikewrap/configs/default.yaml
@@ -11,6 +11,7 @@
   - operator: median
     reference: global
 
+
 'sorting':
   'kilosort2':
     'car': False     # common average referencing
@@ -35,3 +36,7 @@
   'peak_sign': "neg"
   'method': "radius"
   'radius_um': 75
+
+'write_binary_file':
+  'method': "memory_percent"
+  'value': "75"

--- a/spikewrap/examples/example_preprocess.py
+++ b/spikewrap/examples/example_preprocess.py
@@ -26,7 +26,7 @@ loaded_data = load_data(base_path, sub_name, sessions_and_runs, data_format="spi
 
 run_preprocessing(
     loaded_data,
-    pp_steps="default",
+    pp_settings="default",
     handle_existing_data="overwrite",
     log=True,
     slurm_batch=False,

--- a/spikewrap/pipeline/full_pipeline.py
+++ b/spikewrap/pipeline/full_pipeline.py
@@ -189,7 +189,7 @@ def _run_full_pipeline(
     passed_arguments = locals()
     validate.check_function_arguments(passed_arguments)
 
-    pp_steps, sorter_options, waveform_options = get_configs(config_name)
+    pp_steps, sorter_options, waveform_options, write_binary_options = get_configs(config_name)
 
     logs = logging_sw.get_started_logger(
         utils.get_logging_path(base_path, sub_name),
@@ -206,8 +206,9 @@ def _run_full_pipeline(
         config_name,
         existing_preprocessed_data,
         slurm_batch=False,
+        write_binary_options=write_binary_options,
         log=True,
-    )  # TODO: use config_name for all funcs.
+    )  # TODO: use `config_name` for all funcs.
 
     sorting_data = run_sorting(
         base_path,

--- a/spikewrap/pipeline/full_pipeline.py
+++ b/spikewrap/pipeline/full_pipeline.py
@@ -189,7 +189,10 @@ def _run_full_pipeline(
     passed_arguments = locals()
     validate.check_function_arguments(passed_arguments)
 
-    pp_steps, sorter_options, waveform_options, write_binary_options = get_configs(config_name)
+    # TODO: these sorting options are set here, but preprocessing
+    # is set in preprocessing.
+    # TODO: rename all settings e.g. 'pp_settings' to just 'settings_file'.
+    _, sorter_options, waveform_options, _ = get_configs(config_name)
 
     logs = logging_sw.get_started_logger(
         utils.get_logging_path(base_path, sub_name),
@@ -206,7 +209,6 @@ def _run_full_pipeline(
         config_name,
         existing_preprocessed_data,
         slurm_batch=False,
-        write_binary_options=write_binary_options,
         log=True,
     )  # TODO: use `config_name` for all funcs.
 

--- a/spikewrap/pipeline/postprocess.py
+++ b/spikewrap/pipeline/postprocess.py
@@ -80,7 +80,7 @@ def run_postprocess(
 
     # Create / load waveforms
     if waveform_options is None:
-        _, _, waveform_options = get_configs("default")
+        _, _, waveform_options, _ = get_configs("default")
 
     waveforms = run_or_get_waveforms(
         postprocess_data, existing_waveform_data, waveform_options

--- a/spikewrap/pipeline/preprocess.py
+++ b/spikewrap/pipeline/preprocess.py
@@ -1,5 +1,5 @@
 import json
-from typing import Dict, List, Tuple, Union
+from typing import Dict, List, Tuple, Union, Literal, Optional,
 
 import numpy as np
 import spikeinterface.preprocessing as spre
@@ -18,6 +18,7 @@ def run_preprocessing(
     preprocess_data: PreprocessingData,
     pp_steps: str,
     handle_existing_data: HandleExisting,
+    write_binary_options: Dict,
     slurm_batch: Union[bool, Dict] = False,
     log: bool = True,
 ):
@@ -68,12 +69,13 @@ def run_preprocessing(
                 "preprocess_data": preprocess_data,
                 "pp_steps": pp_steps_dict,
                 "handle_existing_data": handle_existing_data,
+                "write_binary_options": write_binary_options,
                 "log": log,
             },
         ),
     else:
         _preprocess_and_save_all_runs(
-            preprocess_data, pp_steps_dict, handle_existing_data, log
+            preprocess_data, pp_steps_dict, handle_existing_data, write_binary_options, log
         )
 
 
@@ -110,6 +112,7 @@ def _preprocess_and_save_all_runs(
     preprocess_data: PreprocessingData,
     pp_steps_dict: Dict,
     handle_existing_data: HandleExisting,
+    write_binary_options: Dict,
     log: bool = True,
 ) -> None:
     """
@@ -141,7 +144,7 @@ def _preprocess_and_save_all_runs(
 
         if to_save:
             _preprocess_and_save_single_run(
-                preprocess_data, ses_name, run_name, pp_steps_dict, overwrite
+                preprocess_data, ses_name, run_name, pp_steps_dict, overwrite, write_binary_options
             )
 
     if log:
@@ -154,6 +157,7 @@ def _preprocess_and_save_single_run(
     run_name: str,
     pp_steps_dict: Dict,
     overwrite: bool,
+    write_binary_options: Dict,
 ) -> None:
     """
     Given a single session and run, fill the entry for this run
@@ -166,7 +170,7 @@ def _preprocess_and_save_single_run(
         pp_steps_dict,
     )
 
-    preprocess_data.save_preprocessed_data(ses_name, run_name, overwrite)
+    preprocess_data.save_preprocessed_data(ses_name, run_name, overwrite, write_binary_options)
 
 
 def _handle_existing_data_options(

--- a/spikewrap/utils/utils.py
+++ b/spikewrap/utils/utils.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Callable, Dict, List, Literal, Tuple, Union
 
 import numpy as np
+import psutil
 import yaml
 
 if TYPE_CHECKING:
@@ -286,3 +287,14 @@ def paths_are_in_datetime_order(
     is_in_time_order = list_of_paths == list_of_paths_by_time
 
     return is_in_time_order
+
+
+def get_chunk_size_based_on_available_memory(write_binary_kwargs: Dict) -> str:
+    """ """
+    proportion = int(write_binary_kwargs["memory_percent"]) / 100
+    memory_GB = psutil.virtual_memory().available / 1e09
+
+    memory_to_use = np.floor(memory_GB * proportion)
+    memory_str = str((memory_to_use.astype(np.int16))) + "G"
+
+    return memory_str


### PR DESCRIPTION
Expose the binary writing file options in spikeinterface as a new entry on the config file. This also include a currently custom option to enter a percent of available memory to use while writing, currently default 75%.

Need to discuss this a little further with SI and wait for https://github.com/SpikeInterface/spikeinterface/issues/2029.

In the end it will take quite a long time to fully optimise and track SI's pre-processing memory footprint, which is not a trivial task. Instead put this to one side and set 1GB memory default, which will work for nearly all modern PCs and at worst case scenario still gives chunk size of 20 minutes!