### PR TITLE
Move sorter configs to a central `utils` function.

### DIFF
--- a/spikewrap/utils/managing_images.py
+++ b/spikewrap/utils/managing_images.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Literal, Optional, Tuple, Union
 
 from ..configs.backend.hpc import hpc_sorter_images_path
-from . import checks
+from . import checks, utils
 
 if TYPE_CHECKING:
     from ..data_classes.sorting import SortingData
@@ -60,7 +60,7 @@ def get_image_run_settings(
     sorter : str
         Sorter name.
     """
-    can_run_locally = ["spykingcircus", "mountainsort5", "tridesclous"]
+    can_run_locally = utils.canonical_settings("sorter_can_run_locally")
 
     if sorter in can_run_locally:
         singularity_image = docker_image = None
@@ -179,7 +179,7 @@ def get_hpc_sorter_path(sorter: str) -> Path:
 def get_sorter_image_name(sorter: str) -> str:
     """
     Get the sorter image name, as defined by how
-    SpikeInterface names the docker images it provides.
+    SpikeInterface names the images it provides.
 
     Parameters
     ----------

--- a/spikewrap/utils/utils.py
+++ b/spikewrap/utils/utils.py
@@ -44,6 +44,25 @@ def canonical_names(name: str) -> str:
     return filenames[name]
 
 
+def canonical_settings(setting: str) -> List:
+    """
+    Centralise all key settings around supported sorters
+    and how they should be run.
+    """
+    canonical_settings = {
+        "supported_sorters": [
+            "kilosort2",
+            "kilosort2_5",
+            "kilosort3",
+            "mountainsort5",
+            "spykingcircus",
+            "tridesclous",
+        ],
+        "sorter_can_run_locally": ["spykingcircus", "mountainsort5", "tridesclous"],
+    }
+    return canonical_settings[setting]
+
+
 def get_formatted_datetime() -> str:
     return datetime.now().strftime("%Y-%m-%d_%H%M%S")
 

--- a/spikewrap/utils/validate.py
+++ b/spikewrap/utils/validate.py
@@ -6,6 +6,7 @@ from typeguard import CollectionCheckStrategy
 
 from ..configs.backend.hpc import default_slurm_options
 from ..data_classes.preprocessing import PreprocessingData
+from ..utils import utils
 from ..utils.custom_types import DeleteIntermediate, HandleExisting
 
 
@@ -52,14 +53,7 @@ def check_function_arguments(arguments):
             if not typecheck(arg_value, str):
                 raise TypeError("`sorter` must be a str indicating the sorter to use.")
 
-            supported_sorters = [
-                "kilosort2",
-                "kilosort2_5",
-                "kilosort3",
-                "mountainsort5",
-                "spykingcircus",
-                "tridesclous",
-            ]
+            supported_sorters = utils.cannonical_settings("supported_sorters")
 
             if arg_value not in supported_sorters:
                 raise ValueError(f"`sorter` must be one of {supported_sorters}")


### PR DESCRIPTION
This PR moves key configurations (supported sorters and whether they can run locally) to a dedicated function in utils. Eventually this should be moved to a backend configs module - but currently its a little confusing as there is also a user-facing configs module exposed. As there are not too many canonical configs keep them here for now.