### PR TITLE
Add split by group

### DIFF
--- a/spikewrap/data_classes/preprocessed_run_recording.py
+++ b/spikewrap/data_classes/preprocessed_run_recording.py
@@ -1,0 +1,126 @@
+from pathlib import Path
+from typing import Literal, Optional, Union
+
+import spikeinterface as si
+
+
+class PreprocessedRunRecording:
+    """ """
+
+    def __init__(
+        self, file_path: Optional[Union[str, Path]] = None, data: Optional[Dict] = None
+    ):
+        self.data = {}
+
+        if file_path is not None:
+            file_path = Path(file_path)
+            self.validate_file_path(file_path)
+            self.load_binary_data(file_path)
+        else:
+            assert isinstance(data, Dict), "TODO"
+            self.data = data
+
+    def validate_file_path(self, file_path: Path) -> None:
+        """
+        does make some assumptiosn this is an spikewrap folder.
+        """
+        if not file_path.is_dir():
+            raise FileNotFounderror(
+                f"The preprocessing folder expected at {file_path} does not exist."
+            )
+
+        if file_path.stem != "si_recording":
+            raise ValueError(
+                f"The folder path passed to PreprocessRunRecording must "
+                f"be called 'si_recording' as it must be a valid output"
+                f"from spikewrap preprocessing. The passed path was"
+                f"{file_path}"
+            )
+
+        if file_path.parent.stem != "preprocessing":
+            raise ValueError(
+                "The folder that `si_recording` is in does not"
+                "seem to be a spikewrap preprocessing folder."
+                "Please check the preprocessing step."
+            )
+
+    def get_folder_contents_and_shank_type(self) -> Literal["single", "multi"]:
+        """"""
+        folder_contents = list(self.file_path.glob("*"))
+        [path_.stem for path_ in self.folder_contents]
+
+        if "shank_0" in self.folder_contents_names:
+            if not all(["shank_" in name for name in self.folder_contents_names]):
+                raise RuntimeError(
+                    f"There is a folder that does not begin with 'shank'"
+                    f"in the preprocessed data folder at {self.file_path}. Please delete"
+                    f"this folder - non-spikewrap files or folders should "
+                    f"never be stored here."
+                )
+
+            return folder_contents, "multi"
+
+        else:
+            for name in [
+                "properties",
+                "binary",
+                "probe",
+                "provenance",
+                "si_folder",
+                "traces_cached_seg0",
+            ]:
+                if name not in self.folder_contents_names:
+                    raise RuntimeError(
+                        f"The file / folder {name} cannot be found in {self.file_path}.",
+                        "There may be a problem when saving the preprocessed file.",
+                        "Please contact spikewrap.",
+                    )
+            return folder_contents, "single"
+
+    def load_binary_data(self, file_path: Path) -> None:
+        folder_contents, shank_type = self.get_folder_contents_and_shank_type(file_path)
+
+        if shank_type == "single":
+            self.data["0"] = si.load_extractor(file_path)
+        else:
+            # use idx so we are sure we are in order.
+            for idx in range(len(folder_contents)):
+                expected_rec_filepath = file_path / f"shank_{idx}"
+                self.data[str(idx)] = si.load_extractor(expected_rec_filepath)
+
+
+def concatenate_preprocessed_run_recordings(
+    recordings: List[PreprocessedRunRecording],
+) -> PreprocessedRunRecording:
+    breakpoint()
+
+    expected_shank_idx = recordings[
+        0
+    ].data.keys()  # figure out data # TODO: ensure these are all in the same order? or at least all increasing
+    for recording in recordings:
+        assert (
+            first_recording_keys == recording.keys()
+        )  # TODO: can we do this equality?
+
+    for shank_idx in expected_shank_idx:
+        breakpoint()
+        expected_chan_idx = recordings[0].data[shank_idx].get_channel_ids()
+        expected_sampling_freq = recordings[0].get_sampling_frequency()
+        expected_dtype = recordings[0].get_dtype()  # TODO: check
+        expected_group_num = recordings[0].get_property("group")
+        for recording in recordings:
+            assert recording.data[shank_idx].get_channel_ids() == expected_chan_idx
+            assert (
+                recording.data[shank_idx].get_sampling_frequency()
+                == expected_sampling_freq
+            )
+            assert recording.data[shank_idx].get_dtype() == expected_dtype
+            assert recording.data[shank_idx].get_property("group") == expected_group_num
+
+    concatenated_data = {}
+    for shank_idx in expected_shank_idx:
+        [recording.data[shank_idx] for recording in recordings]
+        # concat_shank_recordings = # USE SI
+        concatenated_data[shank_idx] = concat_shank_recordings
+
+    return PreprocessedRunRecording(data=concatenated_data)

--- a/spikewrap/data_classes/preprocessing.py
+++ b/spikewrap/data_classes/preprocessing.py
@@ -107,13 +107,33 @@ class PreprocessingData(BaseUserDict):
         """
         Save the fully preprocessed data (i.e. last step in the
         preprocessing chain) to binary file. This is required for sorting.
+
+        If the recording is a `Dict`, then it was split during `run_preprocess`
+        and each recording in the dictionary is a split shank. Otherwise, it
+        is a single (unsplit) recording object.
         """
         recording, __ = utils.get_dict_value_from_step_num(
             self[ses_name][run_name], "last"
         )
-        recording.save(
-            folder=self._get_pp_binary_data_path(ses_name, run_name), chunk_memory="10M"
-        )
+
+        if isinstance(recording, Dict):
+            for shank, rec in recording.items():
+                utils.message_user(
+                    f"Saving preprocessed data for {ses_name}, {run_name}, shank {shank}."
+                )
+
+                rec.save(
+                    folder=self._get_pp_binary_data_path(ses_name, run_name)
+                    / f"shank_{shank}",
+                    chunk_memory="10M",  # TODO: handle duplication.
+                )
+        else:
+            utils.message_user(f"Saving preprocessed data for {ses_name}, {run_name}.")
+
+            recording.save(
+                folder=self._get_pp_binary_data_path(ses_name, run_name),
+                chunk_memory="10M",
+            )
 
     def _save_sync_channel(self, ses_name: str, run_name: str) -> None:
         """

--- a/spikewrap/data_classes/sorting.py
+++ b/spikewrap/data_classes/sorting.py
@@ -13,6 +13,7 @@ from ..utils import utils
 from .base import BaseUserDict
 from .preprocessed_run_recording import (
     PreprocessedRunRecording,
+    concatenate_preprocessed_run_recordings,
 )
 
 if TYPE_CHECKING:
@@ -130,9 +131,14 @@ class SortingData(BaseUserDict, ABC):
         concatenated_recording : si.BaseRecording
             A SI recording object holding the concatenated preprocessed data.
         """
-        breakpoint()
         session_run_names, recordings_list = zip(*recordings[ses_name].items())
-        concatenated_recording = concatenate_recordings(recordings_list)
+
+        concatenated_recording = concatenate_preprocessed_run_recordings(
+            recordings_list
+        )
+
+        # concatenated_recording = concatenate_recordings(recordings_list)
+        breakpoint()
 
         assert session_run_names == tuple(
             self.sessions_and_runs[ses_name]

--- a/spikewrap/data_classes/sorting.py
+++ b/spikewrap/data_classes/sorting.py
@@ -11,6 +11,9 @@ from spikeinterface import concatenate_recordings
 
 from ..utils import utils
 from .base import BaseUserDict
+from .preprocessed_run_recording import (
+    PreprocessedRunRecording,
+)
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -105,8 +108,10 @@ class SortingData(BaseUserDict, ABC):
         """"""
         recordings: Dict = {}
         for ses_name, run_name in self.preprocessing_sessions_and_runs():
-            rec = si.load_extractor(self._get_pp_binary_data_path(ses_name, run_name))
-            utils.update(recordings, ses_name, run_name, value=rec)
+            recording = PreprocessedRunRecording(
+                file_path=self._get_pp_binary_data_path(ses_name, run_name)
+            )
+            utils.update(recordings, ses_name, run_name, value=recording)
 
         return recordings
 
@@ -125,6 +130,7 @@ class SortingData(BaseUserDict, ABC):
         concatenated_recording : si.BaseRecording
             A SI recording object holding the concatenated preprocessed data.
         """
+        breakpoint()
         session_run_names, recordings_list = zip(*recordings[ses_name].items())
         concatenated_recording = concatenate_recordings(recordings_list)
 
@@ -403,6 +409,7 @@ class ConcatenateRuns(SortingData):
 
         for ses_name in self.sessions_and_runs.keys():
             concat_recording = self._concatenate_runs(ses_name, recordings)
+
             utils.update(
                 self.data, ses_name, self.concat_run_name(ses_name), concat_recording
             )

--- a/spikewrap/examples/example_preprocess.py
+++ b/spikewrap/examples/example_preprocess.py
@@ -30,5 +30,5 @@ run_preprocess(
     save_to_file="overwrite",
     log=True,
     slurm_batch=False,
-    preprocess_shanks_separately=True,
+    preprocess_shanks_separately=False,
 )

--- a/spikewrap/examples/example_preprocess.py
+++ b/spikewrap/examples/example_preprocess.py
@@ -29,5 +29,6 @@ run_preprocess(
     pp_steps="default",
     save_to_file="overwrite",
     log=True,
-    slurm_batch=True,
+    slurm_batch=False,
+    preprocess_shanks_separately=True,
 )

--- a/spikewrap/examples/example_sort.py
+++ b/spikewrap/examples/example_sort.py
@@ -21,5 +21,5 @@ if __name__ == "__main__":
         sorter="kilosort2_5",
         concatenate_runs=True,
         concatenate_sessions=False,
-        slurm_batch=True,
+        slurm_batch=False,
     )

--- a/spikewrap/pipeline/full_pipeline.py
+++ b/spikewrap/pipeline/full_pipeline.py
@@ -23,6 +23,7 @@ def run_full_pipeline(
     sorter: str = "kilosort2_5",
     concat_sessions_for_sorting: bool = False,
     concat_runs_for_sorting: bool = False,
+    preprocess_shanks_separately: bool = False,
     existing_preprocessed_data: HandleExisting = "fail_if_exists",
     existing_sorting_output: HandleExisting = "fail_if_exists",
     overwrite_postprocessing: bool = False,
@@ -147,7 +148,12 @@ def run_full_pipeline(
         base_path, sub_name, sessions_and_runs, data_format="spikeglx"
     )
 
-    run_preprocess(loaded_data, pp_steps, save_to_file=existing_preprocessed_data)
+    run_preprocess(
+        loaded_data,
+        pp_steps,
+        save_to_file=existing_preprocessed_data,
+        preprocess_shanks_separately=preprocess_shanks_separately,
+    )
 
     sorting_data = run_sorting(
         base_path,


### PR DESCRIPTION
Superceeded by #151 This approach is not good but here for reference. A much better solution will be to help implement `GroupByRecording` [in SI](https://github.com/SpikeInterface/spikeinterface/issues/2033) that can handle this automagically as a preprocessing step, rather than track multiple separate shank preprocessing folders in the multi-shank case. 