### PR TITLE
Fix platform dependent dependencies in the pyproject.toml file.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,6 @@ dependencies = [
     "docker; platform_system=='Windows'",
 	"docker; platform_system=='Darwin'",
     "spython; platform_system=='Linux'",  # I think missing from SI?
-    "cuda-python",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
 
 dependencies = [
     "spikeinterface==0.98.2",
-    "spython",  # I think missing from SI?
+
     "submitit",
     "PyYAML",
     "toml",
@@ -30,7 +30,9 @@ dependencies = [
     "tridesclous",
     # "spyking-circus", TODO: this is not straightforward, requires mpi4py. TBD if we want to manage this.
     "mountainsort5",
-    "docker",  # TODO: windows only!
+    "docker; platform_system=='Windows'",
+	"docker; platform_system=='Darwin'",
+    "spython; platform_system=='Linux'",  # I think missing from SI?
     "cuda-python",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
     "docker; platform_system=='Windows'",
 	"docker; platform_system=='Darwin'",
     "spython; platform_system=='Linux'",  # I think missing from SI?
+    "cuda-python; platform_system != 'Darwin'",
 ]
 
 [project.urls]


### PR DESCRIPTION
Previously if `docker` was in the dependencies (needed for windows) it would install on linux. Then SI would think you were running docker, try and use docker to pull dependencies and crash. This fixes it by making the installation of `docker` and `spython` platform-specific.