### PR TITLE
Do not install mountainsort on macos and error if try to run.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     # sorter-specific
     "tridesclous",
     # "spyking-circus", TODO: this is not straightforward, requires mpi4py. TBD if we want to manage this.
-    "mountainsort5",
+    "mountainsort5; platform_system != 'Darwin'",
     "docker; platform_system=='Windows'",
 	"docker; platform_system=='Darwin'",
     "spython; platform_system=='Linux'",  # I think missing from SI?

--- a/spikewrap/pipeline/sort.py
+++ b/spikewrap/pipeline/sort.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import platform
 from pathlib import Path
 from typing import Dict, List, Literal, Optional, Union
 
@@ -108,6 +109,9 @@ def run_sorting(
         slurm.run_sorting_slurm(**passed_arguments)
         return None
     assert slurm_batch is False, "SLURM run has slurm_batch set True"
+
+    if sorter == "mountainsort5" and platform.system() == "Darwin":
+        raise EnvironmentError("Mountainsort is not currently supported on macOS.")
 
     logs = logging_sw.get_started_logger(
         utils.get_logging_path(base_path, sub_name),


### PR DESCRIPTION
Mountainsort is not currently supported on macos. This PR will not try and install mountainsort on macos and will raise error if trying to sort with mountainsort on macos. Currently working on building mountainsort wheels for macos, see #115