### PR TITLE
Fix confusing variable chaining when flattening `sessions_and_runs`.

### DIFF
--- a/spikewrap/data_classes/base.py
+++ b/spikewrap/data_classes/base.py
@@ -51,7 +51,7 @@ class BaseUserDict(UserDict):
                 ), "Run names must be string or list of strings"
                 self.sessions_and_runs[key] = [value]
 
-    def preprocessing_sessions_and_runs(self) -> List[Tuple[str, str]]:
+    def flat_sessions_and_runs(self) -> List[Tuple[str, str]]:
         """
         This returns the sessions and runs dictionary flattened so that
         sessions and runs can be iterated over conveniently. `ordered_run_names`

--- a/spikewrap/data_classes/base.py
+++ b/spikewrap/data_classes/base.py
@@ -58,13 +58,9 @@ class BaseUserDict(UserDict):
         is flattened to a long list of all runs, while `ordered_ses_name` carries
         the corresponding session for each run.
         """
-        ordered_run_names = []
-        ordered_ses_names = []
-        for ses, run in self.sessions_and_runs.items():
-            ordered_run_names += run
-            ordered_ses_names += [ses] * len(run)
-
-        return list(zip(ordered_ses_names, ordered_run_names))
+        return [
+            (ses, run) for ses, runs in self.sessions_and_runs.items() for run in runs
+        ]
 
     def _validate_inputs(
         self,

--- a/spikewrap/data_classes/base.py
+++ b/spikewrap/data_classes/base.py
@@ -2,9 +2,8 @@ import fnmatch
 from collections import UserDict
 from collections.abc import ItemsView, KeysView, ValuesView
 from dataclasses import dataclass
-from itertools import chain
 from pathlib import Path
-from typing import Callable, Dict, List, Literal
+from typing import Callable, Dict, List, Literal, Tuple
 
 from ..utils import utils
 
@@ -52,14 +51,18 @@ class BaseUserDict(UserDict):
                 ), "Run names must be string or list of strings"
                 self.sessions_and_runs[key] = [value]
 
-    def preprocessing_sessions_and_runs(self):  # TODO: type hint
-        """"""
-        ordered_ses_names = list(
-            chain(*[[ses] * len(runs) for ses, runs in self.sessions_and_runs.items()])
-        )
-        ordered_run_names = list(
-            chain(*[runs for runs in self.sessions_and_runs.values()])
-        )
+    def preprocessing_sessions_and_runs(self) -> List[Tuple[str, str]]:
+        """
+        This returns the sessions and runs dictionary flattened so that
+        sessions and runs can be iterated over conveniently. `ordered_run_names`
+        is flattened to a long list of all runs, while `ordered_ses_name` carries
+        the corresponding session for each run.
+        """
+        ordered_run_names = []
+        ordered_ses_names = []
+        for ses, run in self.sessions_and_runs.items():
+            ordered_run_names += run
+            ordered_ses_names += [ses] * len(run)
 
         return list(zip(ordered_ses_names, ordered_run_names))
 

--- a/spikewrap/data_classes/preprocessing.py
+++ b/spikewrap/data_classes/preprocessing.py
@@ -44,7 +44,7 @@ class PreprocessingData(BaseUserDict):
 
         self.sync: Dict = {}
 
-        for ses_name, run_name in self.preprocessing_sessions_and_runs():
+        for ses_name, run_name in self.flat_sessions_and_runs():
 
             self.update_two_layer_dict(self, ses_name, run_name, {"0-raw": None})
             self.update_two_layer_dict(self.sync, ses_name, run_name, None)

--- a/spikewrap/data_classes/preprocessing.py
+++ b/spikewrap/data_classes/preprocessing.py
@@ -45,7 +45,6 @@ class PreprocessingData(BaseUserDict):
         self.sync: Dict = {}
 
         for ses_name, run_name in self.flat_sessions_and_runs():
-
             self.update_two_layer_dict(self, ses_name, run_name, {"0-raw": None})
             self.update_two_layer_dict(self.sync, ses_name, run_name, None)
 

--- a/spikewrap/data_classes/sorting.py
+++ b/spikewrap/data_classes/sorting.py
@@ -404,6 +404,7 @@ class ConcatenateRuns(SortingData):
 
             self.update_two_layer_dict(
                 self, ses_name, self.concat_run_name(ses_name), concat_recording
+            )
 
     def get_sorting_sessions_and_runs(self):  # TODO: type
         """"""

--- a/spikewrap/data_classes/sorting.py
+++ b/spikewrap/data_classes/sorting.py
@@ -88,7 +88,7 @@ class SortingData(BaseUserDict, ABC):
                 f"file path {path_.parent}."
             )
 
-        for ses_name, run_name in self.preprocessing_sessions_and_runs():
+        for ses_name, run_name in self.flat_sessions_and_runs():
             assert (
                 prepro_path := self.get_derivatives_run_path(ses_name, run_name)
                 / "preprocessing"
@@ -104,7 +104,7 @@ class SortingData(BaseUserDict, ABC):
     def initialise_preprocessed_recordings_dict(self) -> Dict:
         """"""
         recordings: Dict = {}
-        for ses_name, run_name in self.preprocessing_sessions_and_runs():
+        for ses_name, run_name in self.flat_sessions_and_runs():
             rec = si.load_extractor(self._get_pp_binary_data_path(ses_name, run_name))
             self.update_two_layer_dict(recordings, ses_name, run_name, value=rec)
 
@@ -372,7 +372,7 @@ class ConcatenateSessions(SortingData):
         self.assert_names(ses_name, run_name)
 
         preprocessing_info_paths = []
-        for pp_ses_name, pp_run_name in self.preprocessing_sessions_and_runs():
+        for pp_ses_name, pp_run_name in self.flat_sessions_and_runs():
             preprocessing_info_paths.append(
                 self.get_preprocessing_info_path(pp_ses_name, pp_run_name)
             )

--- a/spikewrap/examples/example_full_pipeline.py
+++ b/spikewrap/examples/example_full_pipeline.py
@@ -4,27 +4,24 @@ from pathlib import Path
 from spikewrap.pipeline.full_pipeline import run_full_pipeline
 
 base_path = Path(
-    # "/ceph/neuroinformatics/neuroinformatics/scratch/jziminski/ephys/code/spikewrap/tests/data/steve_multi_run/time-short-multises"
+    "/ceph/neuroinformatics/neuroinformatics/scratch/jziminski/ephys/code/spikewrap/tests/data/steve_multi_run/time-short-multises"
     # "/ceph/neuroinformatics/neuroinformatics/scratch/jziminski/ephys/test_data/steve_multi_run/1119617/time-short-multises"
     # r"C:\data\ephys\test_data\steve_multi_run\1119617\time-miniscule-mutlises"
-    r"C:\data\ephys\test_data\steve_multi_run\1119617\time-short-multises"
+    # r"C:\data\ephys\test_data\steve_multi_run\1119617\time-short-multises"
     # "/ceph/neuroinformatics/neuroinformatics/scratch/jziminski/ephys/test_data/steve_multi_run/1119617/time-short"
 )
 
 sub_name = "sub-1119617"
 sessions_and_runs = {
-    "ses-001": [
-        "run-001_1119617_LSE1_shank12_g0",
-        #        "run-002_made_up_g0"
+    "ses-001": ["run-001_1119617_LSE1_shank12_g0", "run-002_made_up_g0"],
+    "ses-002": [
+        "run-002_1119617_LSE1_shank12_g0",
+        "run-001_1119617_pretest1_shank12_g0",
     ],
-    #    "ses-002": [
-    #         "run-001_1119617_pretest1_shank12_g0",
-    #         "run-002_1119617_LSE1_shank12_g0",
-    #    ],
-    #    "ses-003": [
-    #        "run-001_1119617_posttest1_shank12_g0",
-    #        "run-002_1119617_pretest1_shank12_g0",
-    #    ],
+    "ses-003": [
+        "run-001_1119617_posttest1_shank12_g0",
+        "run-002_1119617_pretest1_shank12_g0",
+    ],
 }
 
 config_name = "test_default"

--- a/spikewrap/pipeline/load_data.py
+++ b/spikewrap/pipeline/load_data.py
@@ -74,7 +74,7 @@ def _load_spikeglx_data(preprocess_data: PreprocessingData) -> PreprocessingData
 
     See load_data() for parameters.
     """
-    for ses_name, run_name in preprocess_data.preprocessing_sessions_and_runs():
+    for ses_name, run_name in preprocess_data.flat_sessions_and_runs():
         run_path = preprocess_data.get_rawdata_run_path(ses_name, run_name)
         assert run_name == run_path.name, "TODO"
 

--- a/spikewrap/pipeline/preprocess.py
+++ b/spikewrap/pipeline/preprocess.py
@@ -39,7 +39,7 @@ def run_preprocess(
         )
         utils.show_passed_arguments(passed_arguments, "`run_preprocessing`")
 
-    for ses_name, run_name in preprocess_data.preprocessing_sessions_and_runs():
+    for ses_name, run_name in preprocess_data.flat_sessions_and_runs():
         utils.message_user(f"Preprocessing run {run_name}...")
 
         preprocess_path = preprocess_data.get_preprocessing_path(ses_name, run_name)

--- a/tests/test_integration/test_full_pipeline.py
+++ b/tests/test_integration/test_full_pipeline.py
@@ -32,7 +32,7 @@ class TestFullPipeline(BaseTest):
 
         preprocess_data = load_data(*test_info[:3])
 
-        for ses_name, run_name in preprocess_data.preprocessing_sessions_and_runs():
+        for ses_name, run_name in preprocess_data.flat_sessions_and_runs():
             preprocess_data = preprocess.preprocess(
                 preprocess_data, ses_name, run_name, pp_steps
             )
@@ -48,7 +48,7 @@ class TestFullPipeline(BaseTest):
 
         preprocess_data = load_data(*test_info[:3])
 
-        for ses_name, run_name in preprocess_data.preprocessing_sessions_and_runs():
+        for ses_name, run_name in preprocess_data.flat_sessions_and_runs():
             preprocess_data = preprocess.preprocess(
                 preprocess_data, ses_name, run_name, pp_steps
             )


### PR DESCRIPTION
This PR refactors some very confusing code that flattened the `session_and_runs` variable.  This also renames the variable `preprocessing_sessions_and_runs` to `flat_sessions_and_runs` which is clearer.

The purpose of the code section was to flatten the `sessions_and_runs` dictionarity so sessions and runs can be iterated over conveniently. e.g.

```
sessions_and_runs = {
"ses-001": ["run-001", "run-002"],
"ses-002": ["run-001", "run-002"],
}
```

is flattened to 

```
[
["run-001", "run-002", "run-001", "run-002"],
["ses-001", "ses-001", "ses-002", "ses-002"],
]
```

The previous implementation required a docstring explaining the code that was twice as long as the code itself! 