### PR TITLE
Refactor the `utils` function to update a two-level dictionary.

### DIFF
--- a/spikewrap/data_classes/base.py
+++ b/spikewrap/data_classes/base.py
@@ -181,10 +181,10 @@ class BaseUserDict(UserDict):
         Convenience function to allow updating a two-layer
         dictionary even if it is empty.
         """
-        if ses_name in dict_:
-            dict_[ses_name][run_name] = value
-        else:
-            dict_[ses_name] = {run_name: value}
+        if ses_name not in dict_:
+            dict_[ses_name] = {}
+
+        dict_[ses_name][run_name] = value
 
     def keys(self) -> KeysView:
         return self.data.keys()

--- a/spikewrap/data_classes/base.py
+++ b/spikewrap/data_classes/base.py
@@ -175,6 +175,17 @@ class BaseUserDict(UserDict):
             "preprocessed_yaml"
         )
 
+    @staticmethod
+    def update_two_layer_dict(dict_, ses_name, run_name, value):
+        """
+        Convenience function to allow updating a two-layer
+        dictionary even if it is empty.
+        """
+        if ses_name in dict_:
+            dict_[ses_name][run_name] = value
+        else:
+            dict_[ses_name] = {run_name: value}
+
     def keys(self) -> KeysView:
         return self.data.keys()
 

--- a/spikewrap/data_classes/preprocessing.py
+++ b/spikewrap/data_classes/preprocessing.py
@@ -45,8 +45,8 @@ class PreprocessingData(BaseUserDict):
         self.sync: Dict = {}
 
         for ses_name, run_name in self.preprocessing_sessions_and_runs():
-            utils.update(self.data, ses_name, run_name, {"0-raw": None})
-            utils.update(self.sync, ses_name, run_name, None)
+            self.update_two_layer_dict(self.data, ses_name, run_name, {"0-raw": None})
+            self.update_two_layer_dict(self.sync, ses_name, run_name, None)
 
     def set_pp_steps(self, pp_steps: Dict) -> None:
         """

--- a/spikewrap/data_classes/sorting.py
+++ b/spikewrap/data_classes/sorting.py
@@ -106,7 +106,7 @@ class SortingData(BaseUserDict, ABC):
         recordings: Dict = {}
         for ses_name, run_name in self.preprocessing_sessions_and_runs():
             rec = si.load_extractor(self._get_pp_binary_data_path(ses_name, run_name))
-            utils.update(recordings, ses_name, run_name, value=rec)
+            self.update_two_layer_dict(recordings, ses_name, run_name, value=rec)
 
         return recordings
 
@@ -257,7 +257,7 @@ class SortingData(BaseUserDict, ABC):
 
         for load_prepro_path in preprocessing_info_paths:
             pp_dict = utils.load_dict_from_yaml(load_prepro_path)
-            utils.update(
+            self.update_two_layer_dict(
                 sorting_info["preprocessing"],
                 pp_dict["ses_name"],
                 pp_dict["run_name"],
@@ -403,7 +403,7 @@ class ConcatenateRuns(SortingData):
 
         for ses_name in self.sessions_and_runs.keys():
             concat_recording = self._concatenate_runs(ses_name, recordings)
-            utils.update(
+            self.update_two_layer_dict(
                 self.data, ses_name, self.concat_run_name(ses_name), concat_recording
             )
 

--- a/spikewrap/utils/utils.py
+++ b/spikewrap/utils/utils.py
@@ -130,13 +130,6 @@ def load_dict_from_yaml(filepath: Union[Path, str]) -> Dict:
     return loaded_dict
 
 
-def update(dict_, ses_name, run_name, value):
-    try:
-        dict_[ses_name][run_name] = value
-    except KeyError:
-        dict_[ses_name] = {run_name: value}
-
-
 def cast_pp_steps_values(
     pp_steps: Dict, list_or_tuple: Literal["list", "tuple"]
 ) -> None:


### PR DESCRIPTION
This PR refactors the function `utils.update` that performed some gymnastics to handle the case of making a two-layer dictionary from an empty, or one-level dictionary. For example

```
dict_ = {}
dict[key_1][key_2]  = value  # error
```

This PR

1) moves from utils to the class where it is used
2) makes the logic within the function much clearer and renames to something more informative.

Originally we discussed handling the logic within the loop itself, rather than abstracting to this function. However outside of that PR, it turns out function is used quite a lot and removes a fair bit of boilerplate so instead this PR takes the route of cleaning it up as much as possible, rather than removing entirely. 