### PR TITLE
Better document `UserDict` and remove unnecessary references to `self.data`.

### DIFF
--- a/spikewrap/data_classes/base.py
+++ b/spikewrap/data_classes/base.py
@@ -19,15 +19,19 @@ class BaseUserDict(UserDict):
     folder, allowing use of this class for
     preprocessing and sorting.
 
-    Base UserDict that implements the
-    keys(), values() and items() convenience functions."""
+    This class inhereits from UserDict, which allows us to define
+    a dictionary-like object with additional methods. This class can
+    be accessed like a dict e.g. `self[key]`. Under the hood, the
+    dictionary is stored in `self.data`. When inheriting UserDict
+    it is required to implement the `keys()`, `values()` and `items()`
+    convenience functions.
+    """
 
     base_path: Path
     sub_name: str
     sessions_and_runs: Dict[str, List[str]]
 
     def __post_init__(self) -> None:
-        self.data: Dict = {}
         self.base_path = Path(self.base_path)
         self.check_run_names_are_formatted_as_list()
 

--- a/spikewrap/data_classes/preprocessing.py
+++ b/spikewrap/data_classes/preprocessing.py
@@ -45,7 +45,8 @@ class PreprocessingData(BaseUserDict):
         self.sync: Dict = {}
 
         for ses_name, run_name in self.preprocessing_sessions_and_runs():
-            self.update_two_layer_dict(self.data, ses_name, run_name, {"0-raw": None})
+
+            self.update_two_layer_dict(self, ses_name, run_name, {"0-raw": None})
             self.update_two_layer_dict(self.sync, ses_name, run_name, None)
 
     def set_pp_steps(self, pp_steps: Dict) -> None:

--- a/spikewrap/data_classes/sorting.py
+++ b/spikewrap/data_classes/sorting.py
@@ -338,9 +338,7 @@ class ConcatenateSessions(SortingData):
         concat_run_recordings = []
         for ses_name in recordings.keys():
             concat_run_recordings.append(self._concatenate_runs(ses_name, recordings))
-        self.data[self.concat_ses_name()] = concatenate_recordings(
-            concat_run_recordings
-        )
+        self[self.concat_ses_name()] = concatenate_recordings(concat_run_recordings)
 
     def get_sorting_sessions_and_runs(self):  # TODO: type
         return [(self.concat_ses_name(), None)]
@@ -403,9 +401,9 @@ class ConcatenateRuns(SortingData):
 
         for ses_name in self.sessions_and_runs.keys():
             concat_recording = self._concatenate_runs(ses_name, recordings)
+
             self.update_two_layer_dict(
-                self.data, ses_name, self.concat_run_name(ses_name), concat_recording
-            )
+                self, ses_name, self.concat_run_name(ses_name), concat_recording
 
     def get_sorting_sessions_and_runs(self):  # TODO: type
         """"""


### PR DESCRIPTION
The use of `UserDict` is a little obscure, and it is not clear that the dictionary for the `UserDict` object is held in `self.data`. Here, only use `self.data` if necessary, otherwise access dictionary items with `self[key]`. Further, add better documentation on the `UserDict`.