### PR TITLE
Pin versions of probeinterface and neo.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,8 @@ classifiers = [
 
 dependencies = [
     "spikeinterface==0.98.2",
+    "probeinterface==0.2.16",
+    "neo==0.12.0",
     "submitit",
     "PyYAML",
     "toml",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
 
 dependencies = [
     "spikeinterface==0.98.2",
-    "probeinterface==0.2.16",
+    "probeinterface==0.2.18",
     "neo==0.12.0",
     "submitit",
     "PyYAML",


### PR DESCRIPTION
`0.2.17` of probeinterface broke 4-shank NP probes so pin to `0.2.16` for now.