### PR TITLE
Improve image handling

### DIFF
--- a/spikewrap/configs/backend/hpc.py
+++ b/spikewrap/configs/backend/hpc.py
@@ -2,23 +2,12 @@
 Here defaults related to the HPC system `spikewrap` is run on
 (if not running locally) are stored.
 
-
-`hpc_sorter_images_path()`
-    This function returns the default path where singularity images are stored.
-    The purpose of this storage path is to avoid users installing multiple copies
-    across the system. This path can be changed based on the HPC system used and
-    populated with SpikeInterface singularity images.
-
 `default_slurm_options()`
     The default options passed to the submitit executor and converted
     to SLURM batch script arguments. If passing new options in `slurm_batch`,
     the passed options are overriden but other defaults are maintained.
 """
 from typing import Dict
-
-
-def hpc_sorter_images_path() -> str:
-    return "/ceph/neuroinformatics/neuroinformatics/scratch/sorter_images"
 
 
 def default_slurm_options() -> Dict:

--- a/spikewrap/examples/example_full_pipeline.py
+++ b/spikewrap/examples/example_full_pipeline.py
@@ -25,7 +25,7 @@ sessions_and_runs = {
 }
 
 config_name = "test_default"
-sorter = "mountainsort5"  #  "kilosort2_5"  # "spykingcircus" # mountainsort5
+sorter = "kilosort2_5"  #  "kilosort2_5"  # "spykingcircus" # mountainsort5
 
 if __name__ == "__main__":
     t = time.time()
@@ -38,8 +38,8 @@ if __name__ == "__main__":
         sorter,
         concat_sessions_for_sorting=True,  # TODO: validate this at the start, in `run_full_pipeline`
         concat_runs_for_sorting=True,
-        existing_preprocessed_data="overwrite",  # this is kind of confusing...
-        existing_sorting_output="skip_if_exists",
+        existing_preprocessed_data="skip_if_exists",  # this is kind of confusing...
+        existing_sorting_output="overwrite",
         overwrite_postprocessing=True,
         delete_intermediate_files=(),
         #        "recording.dat",

--- a/spikewrap/examples/example_sort.py
+++ b/spikewrap/examples/example_sort.py
@@ -18,8 +18,8 @@ if __name__ == "__main__":
         sub_name,
         sessions_and_runs,
         existing_sorting_output="overwrite",
-        sorter="mountainsort5",
+        sorter="kilosort2",
         concatenate_runs=True,
         concatenate_sessions=False,
-        slurm_batch=True,
+        slurm_batch=False,
     )

--- a/spikewrap/utils/managing_images.py
+++ b/spikewrap/utils/managing_images.py
@@ -9,7 +9,6 @@ from typing import TYPE_CHECKING, Literal, Optional, Tuple, Union
 import spikeinterface
 from spikeinterface.sorters.runsorter import SORTER_DOCKER_MAP
 
-from spikewrap.configs.backend.hpc import hpc_sorter_images_path
 from spikewrap.utils import checks, utils
 
 if TYPE_CHECKING:
@@ -48,7 +47,9 @@ def move_singularity_image_if_required(
         assert (
             platform.system() == "Linux"
         ), "Docker Desktop should be used on Windows or macOS."
-        store_singularity_image(sorting_data.base_path, sorter)
+
+        path_to_image = sorting_data.base_path / get_sorter_image_name(sorter)
+        shutil.move(path_to_image, get_local_sorter_path(sorter).parent)
 
 
 def get_image_run_settings(
@@ -91,25 +92,6 @@ def get_image_run_settings(
     return singularity_image, docker_image  # type: ignore
 
 
-def store_singularity_image(base_path: Path, sorter: str) -> None:
-    """
-    When running locally, SpikeInterface will pull the docker image
-    to the current working directly. Move this to home/.spikewrap
-    so they can be used again in future and are centralised.
-
-    Parameters
-    ----------
-    base_path : Path
-        Base-path on the SortingData object, the path that holds
-        `rawdata` and `derivatives` folders.
-
-    sorter : str
-        Name of the sorter for which to store the image.
-    """
-    path_to_image = base_path / get_sorter_image_name(sorter)
-    shutil.move(path_to_image, get_local_sorter_path(sorter).parent)
-
-
 def get_singularity_image(sorter: str) -> Union[Literal[True], str]:
     """
     Get the path to a pre-installed system singularity image. If none
@@ -131,10 +113,7 @@ def get_singularity_image(sorter: str) -> Union[Literal[True], str]:
     """
     singularity_image: Union[Literal[True], str]
 
-    if get_hpc_sorter_path(sorter).is_file():
-        singularity_image = str(get_hpc_sorter_path(sorter))
-
-    elif get_local_sorter_path(sorter).is_file():
+    if get_local_sorter_path(sorter).is_file():
         singularity_image = str(get_local_sorter_path(sorter))
     else:
         singularity_image = True
@@ -142,7 +121,9 @@ def get_singularity_image(sorter: str) -> Union[Literal[True], str]:
     return singularity_image
 
 
-def get_local_sorter_path(sorter: str) -> Path:
+def get_local_sorter_path(
+    sorter: str, spikeinterface_version: Optional[str] = None
+) -> Path:
     """
     Return the path to a sorter singularity image. The sorters are
     stored by spikewrap in the home folder.
@@ -152,37 +133,30 @@ def get_local_sorter_path(sorter: str) -> Path:
     sorter : str
         The name of the sorter to get the path to (e.g. kilosort2_5).
 
+    spikeinterface_version : Optional[str]
+        The spikeinterface version from which the sorter was stored.
+        Otherwise, use the currently installed version.
+
     Returns
     ---------
     local_path : Path
         The path to the sorter image on the local machine.
     """
+    if spikeinterface_version is None:
+        spikeinterface_version = spikeinterface.__version__
+
     local_path = (
-        Path.home() / ".spikewrap" / "sorter_images" / get_sorter_image_name(sorter)
+        Path.home()
+        / ".spikewrap"
+        / "sorter_images"
+        / sorter
+        / spikeinterface_version
+        / get_sorter_image_name(sorter)
     )
+
     local_path.parent.mkdir(exist_ok=True, parents=True)
+
     return local_path
-
-
-def get_hpc_sorter_path(sorter: str) -> Path:
-    """
-    Return the path to the sorter image on the SWC HCP (ceph).
-
-    Parameters
-    ----------
-    sorter : str
-        The name of the sorter to get the path to (e.g. kilosort2_5).
-
-    Returns
-    -------
-    sorter_path : Path
-        The base to the sorter image on SWC HCP (ceph).
-    """
-    base_path = Path(hpc_sorter_images_path())
-    sorter_path = (
-        base_path / sorter / spikeinterface.__version__ / get_sorter_image_name(sorter)
-    )
-    return sorter_path
 
 
 def get_sorter_image_name(sorter: str) -> str:
@@ -201,7 +175,6 @@ def get_sorter_image_name(sorter: str) -> str:
         The SpikeInterface filename of the docker image for that sorter.
     """
     # use spikeinterface sorter SORTER_DOCKER_MAP
-
     if "kilosort" in sorter:
         sorter_name = f"{sorter}-compiled-base.sif"
     else:
@@ -211,7 +184,7 @@ def get_sorter_image_name(sorter: str) -> str:
     return sorter_name
 
 
-def download_all_sorters(save_to_config_location: bool = True) -> None:
+def download_all_sorters() -> None:
     """
     Convenience function to download all sorters and move them to
     the HPC path (set in configs/backend/hpc.py). This should be run
@@ -220,15 +193,6 @@ def download_all_sorters(save_to_config_location: bool = True) -> None:
 
     The SI images are stored at:
         https://github.com/SpikeInterface/spikeinterface-dockerfiles
-
-    Parameters
-    ----------
-
-    save_to_config_location : bool
-        If `True`, the sorters are saved in the default hpc
-        sorter images path specified in configs/backend/hpc.py
-        If `False`, the sorters are downloaded to the current
-        working direction.
     """
 
     assert platform.system() == "Linux", (
@@ -237,23 +201,29 @@ def download_all_sorters(save_to_config_location: bool = True) -> None:
     )
     from spython.main import Client
 
-    spikeinterface_version = spikeinterface.__version__
+    #    spikeinterface_version = spikeinterface.__version__
 
-    if save_to_config_location:
-        save_to_path = Path(hpc_sorter_images_path()) / spikeinterface_version
-    else:
-        save_to_path = Path(os.getcwd()) / spikeinterface_version
-
-    if save_to_path.is_dir():
-        raise FileExistsError(f"Image folder already exists at {save_to_path}")
-
-    save_to_path.mkdir()
-    os.chdir(save_to_path)
+    #   if save_to_config_location:
+    #      save_to_path = Path(hpc_sorter_images_path()) / spikeinterface_version
+    # else:
+    #    save_to_path = Path(os.getcwd()) / spikeinterface_version
 
     supported_sorters = utils.canonical_settings("supported_sorters")
     can_run_locally = utils.canonical_settings("sorter_can_run_locally")
 
     for sorter in supported_sorters:
         if sorter not in can_run_locally:
+            save_to_path = get_local_sorter_path(sorter)
+
+            if save_to_path.is_dir():
+                raise FileExistsError(f"Image folder already exists at {save_to_path}")
+
+            save_to_path.mkdir()
+            os.chdir(save_to_path)
+
             container_image = SORTER_DOCKER_MAP[sorter]
             Client.pull(f"docker://{container_image}")
+
+
+# hpc_sorter_images_path
+# download_all_sorters

--- a/spikewrap/utils/managing_images.py
+++ b/spikewrap/utils/managing_images.py
@@ -201,25 +201,19 @@ def download_all_sorters() -> None:
     )
     from spython.main import Client
 
-    #    spikeinterface_version = spikeinterface.__version__
-
-    #   if save_to_config_location:
-    #      save_to_path = Path(hpc_sorter_images_path()) / spikeinterface_version
-    # else:
-    #    save_to_path = Path(os.getcwd()) / spikeinterface_version
-
     supported_sorters = utils.canonical_settings("supported_sorters")
     can_run_locally = utils.canonical_settings("sorter_can_run_locally")
 
     for sorter in supported_sorters:
         if sorter not in can_run_locally:
             save_to_path = get_local_sorter_path(sorter)
+            save_to_path_parent = save_to_path.parent
 
-            if save_to_path.is_dir():
+            if save_to_path.is_file():
                 raise FileExistsError(f"Image folder already exists at {save_to_path}")
 
-            save_to_path.mkdir()
-            os.chdir(save_to_path)
+            save_to_path_parent.mkdir(exist_ok=True, parents=True)
+            os.chdir(save_to_path_parent)
 
             container_image = SORTER_DOCKER_MAP[sorter]
             Client.pull(f"docker://{container_image}")

--- a/spikewrap/utils/managing_images.py
+++ b/spikewrap/utils/managing_images.py
@@ -216,6 +216,3 @@ def download_all_sorters() -> None:
 
             container_image = SORTER_DOCKER_MAP[sorter]
             Client.pull(f"docker://{container_image}")
-
-
-# TODO: check all 'hpc' instances in docs

--- a/spikewrap/utils/managing_images.py
+++ b/spikewrap/utils/managing_images.py
@@ -23,8 +23,7 @@ def move_singularity_image_if_required(
     """
     On Linux, images are cased to the sorting_data base folder
     by default by SpikeInterface. To avoid re-downloading
-    images, these are moved to a pre-determined folder (home
-    for local, pre-set on an HPC). This is only required
+    images, these are moved to home directory. This is only required
     for singularity, as docker-desktop handles all image
     storage.
 
@@ -49,7 +48,11 @@ def move_singularity_image_if_required(
         ), "Docker Desktop should be used on Windows or macOS."
 
         path_to_image = sorting_data.base_path / get_sorter_image_name(sorter)
-        shutil.move(path_to_image, get_local_sorter_path(sorter).parent)
+
+        destination = get_local_sorter_path(sorter).parent
+        destination.mkdir(exist_ok=True, parents=True)
+
+        shutil.move(path_to_image, destination)
 
 
 def get_image_run_settings(
@@ -154,8 +157,6 @@ def get_local_sorter_path(
         / get_sorter_image_name(sorter)
     )
 
-    local_path.parent.mkdir(exist_ok=True, parents=True)
-
     return local_path
 
 
@@ -186,10 +187,8 @@ def get_sorter_image_name(sorter: str) -> str:
 
 def download_all_sorters() -> None:
     """
-    Convenience function to download all sorters and move them to
-    the HPC path (set in configs/backend/hpc.py). This should be run
-    when upgrading to a new version of spikeinterface, to ensure
-    the latest image versions are used.
+    Convenience function to download all sorters in the
+    default homee directory.
 
     The SI images are stored at:
         https://github.com/SpikeInterface/spikeinterface-dockerfiles
@@ -219,5 +218,4 @@ def download_all_sorters() -> None:
             Client.pull(f"docker://{container_image}")
 
 
-# hpc_sorter_images_path
-# download_all_sorters
+# TODO: check all 'hpc' instances in docs

--- a/tests/test_integration/test_full_pipeline.py
+++ b/tests/test_integration/test_full_pipeline.py
@@ -65,15 +65,15 @@ class TestFullPipeline(BaseTest):
                 "kilosort2",
                 marks=pytest.mark.skipif(SKIP_KILOSORT, reason="No VM available."),
             ),
-            #          pytest.param(
-            #             "kilosort2_5",
-            #            marks=pytest.mark.skipif(SKIP_KILOSORT, reason="No VM available."),
-            #       ),
-            #      pytest.param(
-            #         "kilosort3",
-            #        marks=pytest.mark.skipif(SKIP_KILOSORT, reason="No VM available."),
-            #   ),
-            #  "mountainsort5",
+            pytest.param(
+                "kilosort2_5",
+                marks=pytest.mark.skipif(SKIP_KILOSORT, reason="No VM available."),
+            ),
+            pytest.param(
+                "kilosort3",
+                marks=pytest.mark.skipif(SKIP_KILOSORT, reason="No VM available."),
+            ),
+            # "mountainsort5",
             # "tridesclous",
         ],
     )

--- a/tests/test_integration/test_managing_images.py
+++ b/tests/test_integration/test_managing_images.py
@@ -10,18 +10,6 @@ class TestManagingImages:
     def test_download_all_sorters(self, tmp_path, monkeypatch):
         """
         Test that `download_all_sorters` downloads the correct sorters.
-        This function will either download to the hpc path set in
-        configs.backend.hpc.hpc_sorter_images_path or to the
-        current working folder.
-
-        If `to_hpc_path` is `True`, the function `hpc_sorter_images_path()`
-        is called to get the path, so we need to monkeypatch it with
-        a pytest temporary test path.
-
-        Otherwise, we can just change the cwd to the `temp_path`.
-
-        Then, simply check that the expected paths are created and
-        expected image files exist.
         """
 
         def new_base_path():

--- a/tests/test_integration/test_managing_images.py
+++ b/tests/test_integration/test_managing_images.py
@@ -1,14 +1,13 @@
-import os
-
-import pytest
 import spikeinterface
 
-from spikewrap.utils.managing_images import download_all_sorters
+from spikewrap.utils.managing_images import (
+    download_all_sorters,
+    get_sorter_image_name,
+)
 
 
 class TestManagingImages:
-    @pytest.mark.parametrize("to_hpc_path", [True, False])
-    def test_download_all_sorters(self, tmp_path, monkeypatch, to_hpc_path):
+    def test_download_all_sorters(self, tmp_path, monkeypatch):
         """
         Test that `download_all_sorters` downloads the correct sorters.
         This function will either download to the hpc path set in
@@ -24,24 +23,26 @@ class TestManagingImages:
         Then, simply check that the expected paths are created and
         expected image files exist.
         """
-        if to_hpc_path:
 
-            def hpc_sorter_images_path2():
-                return str(tmp_path)
+        def new_base_path():
+            return tmp_path
 
-            monkeypatch.setattr(
-                "spikewrap.utils.managing_images.hpc_sorter_images_path",
-                hpc_sorter_images_path2,
-            )
-        else:
-            os.chdir(tmp_path)
+        monkeypatch.setattr(
+            "spikewrap.utils.managing_images.Path.home",
+            new_base_path,
+        )
 
-        download_all_sorters(save_to_config_location=to_hpc_path)
+        download_all_sorters()
 
-        assert (out_path := tmp_path / spikeinterface.__version__).is_dir()
+        for sorter in ["kilosort2", "kilosort2_5", "kilosort3"]:
+            assert (
+                out_path := tmp_path
+                / ".spikewrap"
+                / "sorter_images"
+                / sorter
+                / spikeinterface.__version__
+            ).is_dir()
 
-        downloaded_images = [path_.stem for path_ in out_path.glob("*.sif")]
-
-        assert "kilosort2-compiled-base" in downloaded_images
-        assert "kilosort2_5-compiled-base" in downloaded_images
-        assert "kilosort3-compiled-base" in downloaded_images
+            assert (
+                out_path / get_sorter_image_name(sorter)
+            ).is_file(), f".sif file was not found for {sorter}"


### PR DESCRIPTION
This PR removes the old system of having shared images on the HPC. Now, all sorter images are stored in the users home directory (`Path.home() / ".spikewrap" /...`) in folders named after current spikewrap versions. 