### PR TITLE
Add larger fixed preprocessing save chunk size

### DIFF
--- a/spikewrap/data_classes/preprocessing.py
+++ b/spikewrap/data_classes/preprocessing.py
@@ -111,9 +111,37 @@ class PreprocessingData(BaseUserDict):
         recording, __ = utils.get_dict_value_from_step_num(
             self[ses_name][run_name], "last"
         )
+
         recording.save(
-            folder=self._get_pp_binary_data_path(ses_name, run_name), chunk_memory="10M"
+            folder=self._get_pp_binary_data_path(ses_name, run_name),
+            chunk_size=self.get_default_chunk_size(recording),
         )
+
+    def get_default_chunk_size(self, recording):
+        """
+        Get the fixed default chunk size of 20 minutes of recording.
+        This chunk size was chosen to give a safe memory allocation
+        on nearly all machines (1GB) while giving good data quality (i.e.
+        do not use too many chunks in order to avoid preprocessing
+        filter edge effects)
+
+        The calculation for memory use is:
+        mem_use_bytes = itemsize * sampling_rate * chunk_time_s * error_multiplier
+
+        where
+            itemsize : 8 (some preprocessing steps are in float64)
+            sampling_rate : set by acquisition setup by typically ~30kHz
+            chunk_time_s : time of the chunk in seconds - this adjustable parameter
+                           is set to 20 minutes, leading to ~1 GB memory with other
+                           fixed parameters'
+            error_multiplier : preprocessing steps in SI may use 2-3 times as
+                               much memory due to necessary copies. Therefore
+                               increase the memory estimate by this factor.
+        """
+        sampling_rate = recording.get_sampling_rate()
+        chunk_time_s = 20 * 60
+
+        return sampling_rate * chunk_time_s
 
     def _save_sync_channel(self, ses_name: str, run_name: str) -> None:
         """
@@ -127,9 +155,12 @@ class PreprocessingData(BaseUserDict):
             self.sync[ses_name][run_name] is not None
         ), f"Sync channel on PreprocessData session {ses_name} run {run_name} is None"
 
-        self.sync[ses_name][run_name].save(  # type: ignore
+        breakpoint()
+        sync_recording = self.sync[ses_name][run_name]
+
+        sync_recording.save(  # type: ignore
             folder=self._get_sync_channel_data_path(ses_name, run_name),
-            chunk_memory="10M",
+            chunk_size=self.get_default_chunk_size(sync_recording),
         )
 
     def _save_preprocessing_info(self, ses_name: str, run_name: str) -> None:


### PR DESCRIPTION
Further to #104 this PR implements the first steps, taking up to 1GB with a very liberal memory allocation for SI (maximum possible datatype size used in preprocessing, 2x error multiplier). In future 1GB can be increased based on available memory (see #104) and far down the line when SI memory use is fully optimised the conversative allocation can be removed.