### PR TITLE
Cast to float and add spikeinterface reader.

### DIFF
--- a/spikewrap/data_classes/base.py
+++ b/spikewrap/data_classes/base.py
@@ -1,11 +1,13 @@
-import fnmatch
 from collections import UserDict
 from collections.abc import ItemsView, KeysView, ValuesView
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Callable, Dict, List, Literal, Tuple
+from typing import TYPE_CHECKING, Callable, Dict, List, Literal, Tuple
 
 from spikewrap.utils import utils
+
+if TYPE_CHECKING:
+    import fnmatch
 
 
 @dataclass
@@ -110,23 +112,25 @@ class BaseUserDict(UserDict):
                     f"file path {run_path.parent}."
                 )
 
-                gate_str = fnmatch.filter(run_name.split("_"), "g?")
+                if False:
+                    if self.filetype == "spikeglx":
+                        gate_str = fnmatch.filter(run_name.split("_"), "g?")
 
-                assert len(gate_str) > 0, (
-                    f"The SpikeGLX gate index should be in the run name. "
-                    f"It was not found in the name {run_name}."
-                    f"\nEnsure the gate number is in the SpikeGLX-output filename."
-                )
+                        assert len(gate_str) > 0, (
+                            f"The SpikeGLX gate index should be in the run name. "
+                            f"It was not found in the name {run_name}."
+                            f"\nEnsure the gate number is in the SpikeGLX-output filename."
+                        )
 
-                assert len(gate_str) == 1, (
-                    f"The SpikeGLX gate appears in the name "
-                    f"{run_name} more than once"
-                )
+                        assert len(gate_str) == 1, (
+                            f"The SpikeGLX gate appears in the name "
+                            f"{run_name} more than once"
+                        )
 
-                assert int(gate_str[0][1:]) == 0, (
-                    f"Gate with index larger than 0 is not supported. This is found "
-                    f"in run name {run_name}. "
-                )
+                        assert int(gate_str[0][1:]) == 0, (
+                            f"Gate with index larger than 0 is not supported. This is found "
+                            f"in run name {run_name}. "
+                        )
 
     # Rawdata Paths --------------------------------------------------------------
 

--- a/spikewrap/pipeline/full_pipeline.py
+++ b/spikewrap/pipeline/full_pipeline.py
@@ -22,6 +22,7 @@ def run_full_pipeline(
     base_path: Union[Path, str],
     sub_name: str,
     sessions_and_runs: Dict[str, List[str]],
+    data_format,
     config_name: str = "default",
     sorter: str = "kilosort2_5",
     concat_sessions_for_sorting: bool = False,
@@ -46,6 +47,7 @@ def run_full_pipeline(
                 "base_path": base_path,
                 "sub_name": sub_name,
                 "sessions_and_runs": sessions_and_runs,
+                "data_format": data_format,
                 "config_name": config_name,
                 "sorter": sorter,
                 "concat_sessions_for_sorting": concat_sessions_for_sorting,
@@ -62,6 +64,7 @@ def run_full_pipeline(
             base_path,
             sub_name,
             sessions_and_runs,
+            data_format,
             config_name,
             sorter,
             concat_sessions_for_sorting,
@@ -78,6 +81,7 @@ def _run_full_pipeline(
     base_path: Union[Path, str],
     sub_name: str,
     sessions_and_runs: Dict[str, List[str]],
+    data_format: str,
     config_name: str = "default",
     sorter: str = "kilosort2_5",
     concat_sessions_for_sorting: bool = False,
@@ -198,7 +202,10 @@ def _run_full_pipeline(
     utils.show_passed_arguments(passed_arguments, "`run_full pipeline`")
 
     loaded_data = load_data(
-        base_path, sub_name, sessions_and_runs, data_format="spikeglx"
+        base_path,
+        sub_name,
+        sessions_and_runs,
+        data_format=data_format,
     )
 
     run_preprocessing(


### PR DESCRIPTION
This PR automatically casts to float for pre-processing after overflow errors were discovered in some routines as SI will by default pre-process with the  recording `dtype` which is int16 by default.

This PR also adds `spikeinterface` loading which is necessary for future test PR. Unfortunately these two additions were combined in a single set of commits so this PR merges both together.

NOTE!

There are a number of TODO's and a whole block of validation that is made unreachable. This is because the codebase is in flux prior to a major upcoming PR that will fix all tests and perform a major refactor. After this the first stable version will be released.