### PR TITLE
Preprocessing and Sorting UserDict print the dict not class

### DIFF
--- a/spikewrap/data_classes/preprocessing.py
+++ b/spikewrap/data_classes/preprocessing.py
@@ -51,6 +51,13 @@ class PreprocessingData(BaseUserDict):
             self.update_two_layer_dict(self, ses_name, run_name, {"0-raw": None})
             self.update_two_layer_dict(self.sync, ses_name, run_name, None)
 
+    def __repr__(self):
+        """
+        Show the dict not the class.
+        This does not work on base class.
+        """
+        return self.data.__repr__()
+
     def set_orig_dtype(self, dtype):  # TODO: type dtype!
         """used for writing data"""
         self.orig_dtype = dtype

--- a/spikewrap/data_classes/sorting.py
+++ b/spikewrap/data_classes/sorting.py
@@ -73,6 +73,13 @@ class SortingData(BaseUserDict, ABC):
 
         self.load_preprocessed_binary()
 
+    def __repr__(self):
+        """
+        Show the dict not the class.
+        This does not work on base class.
+        """
+        return self.data.__repr__()
+
     # Checkers
     # ----------------------------------------------------------------------------------
 


### PR DESCRIPTION
Override `__repr__` to print a UserDict dictionary, not class which is default and confusing to user expecting dict.

closes #156 

Unfortunately adding this to base.py does not work for some unkown reason.