### PR TITLE
Fix missing expand `all` and `only` keywords in sorting.

### DIFF
--- a/spikewrap/data_classes/base.py
+++ b/spikewrap/data_classes/base.py
@@ -111,13 +111,12 @@ class BaseUserDict(UserDict):
 
         if has_ses_keyword and ses_keyword is not None:
             ses_name_filepaths = (sub_path := get_sub_path()).glob("ses-*")
-            # TODO: is stem?
+
             all_session_names = [
-                path_.stem for path_ in ses_name_filepaths if path_.is_dir()
+                path_.name for path_ in ses_name_filepaths if path_.is_dir()
             ]
 
             all_session_names = self.check_and_sort_globbed_names(all_session_names)
-            # TODO: need to sort all session names and then check these names are still in the correct order! If they are not we need to do something....
 
             self.raise_if_only_and_has_more_than_one_folder(
                 ses_keyword, sub_path, all_session_names, "session"
@@ -138,10 +137,7 @@ class BaseUserDict(UserDict):
             )
 
             if has_run_keyword:
-                all_run_paths = (
-                    ses_path := get_ses_path(ses_name)
-                    / "ephys"  # TODO: this is going to be everywhere so will need own function
-                ).glob("*")
+                all_run_paths = (ses_path := get_ses_path(ses_name)).glob("*")
 
                 run_names = [path_.stem for path_ in all_run_paths if path_.is_dir()]
 
@@ -268,10 +264,10 @@ class BaseUserDict(UserDict):
         return self.get_rawdata_top_level_path() / self.sub_name
 
     def get_rawdata_ses_path(self, ses_name: str) -> Path:
-        return self.get_rawdata_sub_path() / ses_name
+        return self.get_rawdata_sub_path() / ses_name / "ephys"
 
     def get_rawdata_run_path(self, ses_name: str, run_name: str) -> Path:
-        return self.get_rawdata_ses_path(ses_name) / "ephys" / run_name
+        return self.get_rawdata_ses_path(ses_name) / run_name
 
     # Derivatives Paths --------------------------------------------------------------
 

--- a/spikewrap/data_classes/sorting.py
+++ b/spikewrap/data_classes/sorting.py
@@ -68,6 +68,10 @@ class SortingData(BaseUserDict, ABC):
     def __post_init__(self) -> None:
         super().__post_init__()
 
+        self._convert_session_and_run_keywords_to_foldernames(
+            self.get_derivatives_sub_path,
+            self.get_derivatives_ses_path,
+        )
         self._validate_derivatives_inputs()
         self._check_preprocessing_exists()
 

--- a/spikewrap/examples/example_full_pipeline.py
+++ b/spikewrap/examples/example_full_pipeline.py
@@ -4,13 +4,16 @@ from pathlib import Path
 from spikewrap.pipeline.full_pipeline import run_full_pipeline
 
 base_path = Path(
-    r"/ceph/neuroinformatics/neuroinformatics/scratch/jziminski/ephys/test_data/steve_multi_run/1119617/time-long_origdata"
+    r"C:\fMRIData\git-repo\spikewrap\tests\data\small_toy_data"
+    # r"/ceph/neuroinformatics/neuroinformatics/scratch/jziminski/ephys/test_data/steve_multi_run/1119617/time-long_origdata"
 )
 
-sub_name = "1119617"
-sessions_and_runs = {
-    "ses-001": ["1119617_LSE1_shank12_g0"],
-}
+sub_name = "sub-001_type-test"
+sessions_and_runs = {"all": ["all"]}
+# sub_name = "1119617"
+# sessions_and_runs = {
+#    "ses-001": ["1119617_LSE1_shank12_g0"],
+# }
 
 config_name = "test_default"
 sorter = "mountainsort5"  #  "kilosort2_5"  # "spykingcircus" # mountainsort5
@@ -22,13 +25,15 @@ if __name__ == "__main__":
         base_path,
         sub_name,
         sessions_and_runs,
-        "spikeglx",
+        "spikeinterface",
         config_name,
         sorter,
         save_preprocessing_chunk_size=30000,
         existing_preprocessed_data="overwrite",
-        concat_sessions_for_sorting=True,  # TODO: validate this at the start, in `run_full_pipeline`
-        concat_runs_for_sorting=True,
+        existing_sorting_output="overwrite",
+        overwrite_postprocessing=True,
+        concat_sessions_for_sorting=False,  # TODO: validate this at the start, in `run_full_pipeline`
+        concat_runs_for_sorting=False,
         #        existing_preprocessed_data="skip_if_exists",  # this is kind of confusing...
         #       existing_sorting_output="overwrite",
         #      overwrite_postprocessing=True,


### PR DESCRIPTION
This PR pushes a fix for #154 in which `all` and `only` was not added to sorting. Currently there are no unit tests for this on `sorting`, see #166 .