### PR TITLE
Fix community docs.

### DIFF
--- a/docs/source/community/contributing_guidelines.md
+++ b/docs/source/community/contributing_guidelines.md
@@ -1,6 +1,6 @@
 # Contributing Guide
 
-**Contributions to `spikewrap`` are very welcome and appreciated. This could be
+Contributions to ``spikewrap`` are very welcome and appreciated. This could be
 fixing a bug, improving the documentation or developing a new feature.
 
 If you're unsure about any part of the contributing process or have any questions, please

--- a/docs/source/community/index.md
+++ b/docs/source/community/index.md
@@ -1,19 +1,12 @@
 (community)=
 # Community
 
-We are very keen to get feedback on ``spikewrap``. Does this interface for running electrophysiology analysis will work for you?
-
-
-
-WE WANT FEEDBACK! X_)X)X)X)X)X)X)X)
-
-
-
+Contributions are welcome and encouraged, please see our [Contributing Guidelines](contributing_guidelines).
 
 Please get in contact with feedback and suggestions, either by joining our 
 [Zulip Chat](https://neuroinformatics.zulipchat.com/#narrow/channel/406002-Spikewrap)
 or opening a
-[GitHub Issue](https://github.com/neuroinformatics-unit/spikewrap/issues)
+[GitHub Issue](https://github.com/neuroinformatics-unit/spikewrap/issues).
 
 After a round of feedback, we plan to extend the ``spikewrap``'s features—
 see our [Roadmap](roadmap) for details.


### PR DESCRIPTION
Somehow the community docs got [weirdly edited](https://github.com/neuroinformatics-unit/spikewrap/blame/24188e4baac889bfcf88ff602e055380fdeeee3a/docs/source/community/index.md#L8) in a previous update. I'm not sure how this happened, fixed here.