### PR TITLE
[Fix #187] Update docs to include phase_shift

### DIFF
--- a/docs/source/galleries/how_to/01_preprocess_a_session.py
+++ b/docs/source/galleries/how_to/01_preprocess_a_session.py
@@ -48,8 +48,9 @@ if __name__ == "__main__":  # for multiprocessing
 if __name__ == "__main__":
 
     pp_steps = {
-        "1": ["bandpass_filter", {"freq_min": 300, "freq_max": 6000}],
-        "2": ["common_reference", {"operator": "median"}],
+        "1": ["phase_shift", {}],  
+        "2": ["bandpass_filter", {"freq_min": 300, "freq_max": 6000}],
+        "3": ["common_reference", {"operator": "median", "reference": "global"}],
     }
 
     session.preprocess(configs=pp_steps, per_shank=False, concat_runs=False)

--- a/docs/source/galleries/tutorials/01_preprocessing_sessions.py
+++ b/docs/source/galleries/tutorials/01_preprocessing_sessions.py
@@ -190,7 +190,7 @@ pp_attempt_2 = copy.deepcopy(configs)
 # This is currently quite verbose. It is the second preprocessing
 # step, second element of the list ["function_name", {function_kwargs...}]
 # (see processing dictionary defined above)
-pp_attempt_2["preprocessing"]["2"][1]["operator"] = "average"
+pp_attempt_2["preprocessing"]["3"][1]["operator"] = "average"
 
 session.preprocess(
     configs=pp_attempt_2,

--- a/docs/source/galleries/tutorials/01_preprocessing_sessions.py
+++ b/docs/source/galleries/tutorials/01_preprocessing_sessions.py
@@ -137,8 +137,9 @@ configs = {
 # :class:`spikewrap.Session.preprocess()` will also accept a dictionary with the top-level omitted
 
 pp_steps = {
-    "1": ["bandpass_filter", {"freq_min": 300, "freq_max": 6000}],
-    "2": ["common_reference", {"operator": "median"}],
+    "1": ["phase_shift", {}],
+    "2": ["bandpass_filter", {"freq_min": 300, "freq_max": 6000}],
+    "3": ["common_reference", {"operator": "median"}],
 }
 
 # %%

--- a/docs/source/galleries/tutorials/01_preprocessing_sessions.py
+++ b/docs/source/galleries/tutorials/01_preprocessing_sessions.py
@@ -128,8 +128,9 @@ sw.show_configs("neuropixels+kilosort2_5")
 
 configs = {
     "preprocessing": {
-        "1": ["bandpass_filter", {"freq_min": 300, "freq_max": 6000}],
-        "2": ["common_reference", {"operator": "median"}],
+        "1": ["phase_shift", {}],
+        "2": ["bandpass_filter", {"freq_min": 300, "freq_max": 6000}],
+        "3": ["common_reference", {"operator": "median"}],
     }
 }
 


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [ ] Addition of a new feature
- [x] Other

**Why is this PR needed?**
This PR addresses the issue where the phase_shift step was missing from the documentation example. The neuropixels+kilosort2_5 configuration was updated to include the phase_shift step, but this was not reflected in the example, which was causing confusion.

**What does this PR do?**
This PR updates the documentation to include the missing phase_shift preprocessing step in the example configuration, making it consistent with the updated preprocessing pipeline.

## References
Issue #187 : Fix documentation example (this PR addresses the missing phase_shift step in the example)

## How has this PR been tested?
The updated documentation was built locally, and the example now includes the phase_shift step, ensuring consistency with the updated configuration. The documentation was verified by running the sphinx-build command.

## Is this a breaking change?
No

## Does this PR require an update to the documentation?
Yes, the documentation was updated to include the phase_shift preprocessing step in the example configuration. 

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
