### PR TITLE
[Fix-186] Separate openephys legacy vs binary

### DIFF
--- a/spikewrap/process/_loading.py
+++ b/spikewrap/process/_loading.py
@@ -6,26 +6,28 @@ from typing import TYPE_CHECKING, Literal
 if TYPE_CHECKING:
     from spikeinterface.core import BaseRecording
 
+
 import re
 import warnings
 
+import spikeinterface.extractors as si_extractors
 import spikeinterface.full as si
 
 from spikewrap.utils import _utils
 
 
 def load_data(
-    run_path: Path, file_format: Literal["spikeglx", "openephys"], probe  # TODO: TYPE!
+    run_path: Path, file_format: Literal["spikeglx", "openephys"], probe: Probe | None
 ) -> tuple[BaseRecording, BaseRecording]:
     """
-    explain (e.g. without sync needed for sorting, otherwise store sync for
-    storing the sync array!
+    TODO: add note that must juggle two recordings has probe is not loaded on sync recording!
+
     """
     _utils.message_user(f"Loading data from path: {run_path}")
 
     if file_format == "spikeglx":
         without_sync, with_sync = [
-            si.read_spikeglx(
+            si_extractors.read_spikeglx(
                 folder_path=run_path,
                 stream_id="imec0.ap",
                 all_annotations=True,
@@ -91,7 +93,7 @@ def load_data(
 # exactly the process described in the documentation.
 
 
-def get_run_paths(
+def get_raw_run_paths(
     file_format: Literal["spikeglx", "openephys"],
     ses_path: Path,
     passed_run_names: Literal["all"] | list[str],
@@ -168,9 +170,32 @@ def get_spikeglx_runs(ses_path: Path) -> list[Path]:
     list of Path
         A list of validated run paths, each contain one recording.
     """
-    detected_run_paths = [
-        path_ for path_ in ses_path.glob("*g*_imec*") if path_.is_dir()
-    ]
+
+    # Look for spikeglx runs, either folders at the session level that include
+    # pattern like "g0_imec" or contain a folder that does.
+    putative_run_paths = [path_ for path_ in ses_path.glob("*") if path_.is_dir()]
+    detected_run_paths = []
+
+    for path_ in putative_run_paths:
+
+        # If the run contains spikeglx files
+        if any(path_.glob("*.ap.bin")):
+            detected_run_paths.append(path_)
+
+        # Otherwise if the putative run folder contains a
+        # spikeglx-formatted folder then it is a run folder
+        # (spikeinterface will auto-detect data recursively from
+        # this folder down, which is why we only allow one folder
+        # within the run folder in this case.
+        else:
+            subpath_ = list(path_.glob("*g*imec*"))
+            if any(subpath_):
+                if not len(subpath_) == 1:
+                    raise RuntimeError(
+                        f"Multiple gates / triggers are not supported. Only one folder"
+                        f"expected in path: {path_}"
+                    )
+            detected_run_paths.append(path_)
 
     # Currently, only imec0 supported
     for path_ in detected_run_paths:
@@ -189,7 +214,9 @@ def get_spikeglx_runs(ses_path: Path) -> list[Path]:
 
     # Currently, multi-trigger not supported
     for path_ in detected_run_paths:
-        rec_paths = list(path_.glob("*.bin"))
+        rec_paths = list(
+            path_.rglob("*ap.bin")  # currently LFP not supported.
+        )  # rglob as we might have two-level run folder (TODO: DOC)
         if len(rec_paths) > 1:
             raise RuntimeError(
                 f"The run folder {path_} contains more than one recording.\n"

--- a/spikewrap/process/_loading.py
+++ b/spikewrap/process/_loading.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from pathlib import Path  # Move Path outside TYPE_CHECKING
+from pathlib import Path  # Moved Path outside TYPE_CHECKING
 from typing import TYPE_CHECKING, Literal
 
 if TYPE_CHECKING:

--- a/spikewrap/process/_loading.py
+++ b/spikewrap/process/_loading.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from pathlib import Path  #Move Path outside TYPE_CHECKING
+from pathlib import Path  # Move Path outside TYPE_CHECKING
 from typing import TYPE_CHECKING, Literal
 
 if TYPE_CHECKING:

--- a/spikewrap/process/_loading.py
+++ b/spikewrap/process/_loading.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
-from pathlib import Path  # Moved Path outside TYPE_CHECKING
 from typing import TYPE_CHECKING, Literal
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     from probeinterface import Probe
     from spikeinterface.core import BaseRecording
-
 
 import re
 import warnings

--- a/spikewrap/process/_loading.py
+++ b/spikewrap/process/_loading.py
@@ -12,7 +12,6 @@ import re
 import warnings
 
 import spikeinterface.extractors as si_extractors
-import spikeinterface.full as si
 
 from spikewrap.utils import _utils
 

--- a/spikewrap/process/_loading.py
+++ b/spikewrap/process/_loading.py
@@ -45,7 +45,7 @@ def load_data(
                 "Please contact the spikewrap team if you would like to see this supported."
             )
 
-        without_sync = si.read_openephys(
+        without_sync = si_extractors.read_openephys(
             folder_path=run_path,
             all_annotations=True,
             load_sync_channel=False,

--- a/spikewrap/process/_loading.py
+++ b/spikewrap/process/_loading.py
@@ -51,7 +51,7 @@ def load_data(
             load_sync_channel=False,
         )
         try:
-            with_sync = si.read_openephys(
+            with_sync = si_extractors.read_openephys(
                 folder_path=run_path,
                 all_annotations=False,
                 load_sync_channel=True,

--- a/spikewrap/process/_loading.py
+++ b/spikewrap/process/_loading.py
@@ -4,6 +4,7 @@ from pathlib import Path  # Move Path outside TYPE_CHECKING
 from typing import TYPE_CHECKING, Literal
 
 if TYPE_CHECKING:
+    from probeinterface import Probe
     from spikeinterface.core import BaseRecording
 
 

--- a/tests/test_integration/test_openephys.py
+++ b/tests/test_integration/test_openephys.py
@@ -17,7 +17,7 @@ class TestLegacyOpenEphysLoading:
         )
         node_path = session_path / "Record Node 103"
         node_path.mkdir(parents=True, exist_ok=True)
-        # Create `structure.openephys` to mock a legacy dataset
+        # Create `structure.openephys` to detect a legacy dataset
         (node_path / "structure.openephys").touch()
         return session_path
 

--- a/tests/test_integration/test_openephys.py
+++ b/tests/test_integration/test_openephys.py
@@ -25,7 +25,6 @@ class TestLegacyOpenEphysLoading:
         """
         Ensure that load_data() properly detects `structure.openephys` and raises an error.
         """
-
         with pytest.raises(RuntimeError) as e:
             load_data(legacy_openephys_session_path, "openephys", probe=None)
         assert "Legacy OpenEphys format is not supported." in str(e.value)

--- a/tests/test_integration/test_openephys.py
+++ b/tests/test_integration/test_openephys.py
@@ -17,7 +17,7 @@ class TestLegacyOpenEphysLoading:
         )
         node_path = session_path / "Record Node 103"
         node_path.mkdir(parents=True, exist_ok=True)
-        # Create `structure.openephys` to detect a legacy dataset
+        # Create `structure.openephys` to detect legacy format
         (node_path / "structure.openephys").touch()
         return session_path
 

--- a/tests/test_integration/test_openephys.py
+++ b/tests/test_integration/test_openephys.py
@@ -1,7 +1,7 @@
 import pytest
-from unittest.mock import patch
-from pathlib import Path
-from spikewrap.process._loading import load_data 
+
+from spikewrap.process._loading import load_data
+
 
 def create_dummy_openephys_folder(base_dir):
     """Create a fake OpenEphys directory with a legacy structure.openephys file."""
@@ -12,14 +12,15 @@ def create_dummy_openephys_folder(base_dir):
     (node_path / "structure.openephys").touch()
     return session_path
 
+
 def test_legacy_openephys_detection(tmp_path):
     """
     Ensure that load_data() properly detects `structure.openephys` and raises an error.
     If it does NOT raise an error, explicitly fail the test.
     """
-   
+
     session_path = create_dummy_openephys_folder(tmp_path)
-    
+
     # check for legacy format
     legacy_format = any(session_path.rglob("structure.openephys"))
 

--- a/tests/test_integration/test_openephys.py
+++ b/tests/test_integration/test_openephys.py
@@ -21,12 +21,9 @@ def test_legacy_openephys_detection(tmp_path):
 
     session_path = create_dummy_openephys_folder(tmp_path)
 
-    # check for legacy format
-    legacy_format = any(session_path.rglob("structure.openephys"))
-
     # Try calling `load_data()` and check if it raises an error
     try:
-        # Make sure load_data gets to legacy check first
+        # Make sure load_data gets to our legacy check first
         load_data(session_path, "openephys", probe=None)
         # If no error was raised, fail the test
         pytest.fail("Function is NOT detecting `structure.openephys`. Test failed.")

--- a/tests/test_integration/test_openephys.py
+++ b/tests/test_integration/test_openephys.py
@@ -1,32 +1,31 @@
+from __future__ import annotations
+
 import pytest
 
 from spikewrap.process._loading import load_data
 
 
-def create_dummy_openephys_folder(base_dir):
-    """Create a fake OpenEphys directory with a legacy structure.openephys file."""
-    session_path = base_dir / "rawdata" / "sub-001_id-000001" / "ses-01_date-20230717"
-    node_path = session_path / "Record Node 103"
-    node_path.mkdir(parents=True, exist_ok=True)
-    # Create `structure.openephys` to simulate a legacy dataset
-    (node_path / "structure.openephys").touch()
-    return session_path
+class TestLegacyOpenEphysLoading:
+    @pytest.fixture
+    def legacy_openephys_session_path(self, tmp_path):
+        """
+        Create a fake OpenEphys directory with a legacy `structure.openephys` file,
+        then return the session path.
+        """
+        session_path = (
+            tmp_path / "rawdata" / "sub-001_id-000001" / "ses-01_date-20230717"
+        )
+        node_path = session_path / "Record Node 103"
+        node_path.mkdir(parents=True, exist_ok=True)
+        # Create `structure.openephys` to mock a legacy dataset
+        (node_path / "structure.openephys").touch()
+        return session_path
 
+    def test_legacy_openephys_detection(self, legacy_openephys_session_path):
+        """
+        Ensure that load_data() properly detects `structure.openephys` and raises an error.
+        """
 
-def test_legacy_openephys_detection(tmp_path):
-    """
-    Ensure that load_data() properly detects `structure.openephys` and raises an error.
-    If it does NOT raise an error, explicitly fail the test.
-    """
-
-    session_path = create_dummy_openephys_folder(tmp_path)
-
-    # Try calling `load_data()` and check if it raises an error
-    try:
-        # Make sure load_data gets to our legacy check first
-        load_data(session_path, "openephys", probe=None)
-        # If no error was raised, fail the test
-        pytest.fail("Function is NOT detecting `structure.openephys`. Test failed.")
-    except RuntimeError as e:
-        # If RuntimeError is raised, check if it's the expected error
-        assert "Legacy OpenEphys format is not supported." in str(e)
+        with pytest.raises(RuntimeError) as e:
+            load_data(legacy_openephys_session_path, "openephys", probe=None)
+        assert "Legacy OpenEphys format is not supported." in str(e.value)

--- a/tests/test_integration/test_openephys.py
+++ b/tests/test_integration/test_openephys.py
@@ -1,0 +1,34 @@
+import pytest
+from unittest.mock import patch
+from pathlib import Path
+from spikewrap.process._loading import load_data 
+
+def create_dummy_openephys_folder(base_dir):
+    """Create a fake OpenEphys directory with a legacy structure.openephys file."""
+    session_path = base_dir / "rawdata" / "sub-001_id-000001" / "ses-01_date-20230717"
+    node_path = session_path / "Record Node 103"
+    node_path.mkdir(parents=True, exist_ok=True)
+    # Create `structure.openephys` to simulate a legacy dataset
+    (node_path / "structure.openephys").touch()
+    return session_path
+
+def test_legacy_openephys_detection(tmp_path):
+    """
+    Ensure that load_data() properly detects `structure.openephys` and raises an error.
+    If it does NOT raise an error, explicitly fail the test.
+    """
+   
+    session_path = create_dummy_openephys_folder(tmp_path)
+    
+    # check for legacy format
+    legacy_format = any(session_path.rglob("structure.openephys"))
+
+    # Try calling `load_data()` and check if it raises an error
+    try:
+        # Make sure load_data gets to legacy check first
+        load_data(session_path, "openephys", probe=None)
+        # If no error was raised, fail the test
+        pytest.fail("Function is NOT detecting `structure.openephys`. Test failed.")
+    except RuntimeError as e:
+        # If RuntimeError is raised, check if it's the expected error
+        assert "Legacy OpenEphys format is not supported." in str(e)


### PR DESCRIPTION
## Description
Handle legacy OpenEphys format in read_openephys to prevent invalid load_sync_channel error

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
To raise an error if legacy format is passed.

**What does this PR do?**
Currently, read_openephys() in spikeinterface does not handle legacy OpenEphys formats correctly. When attempting to load data using spikewrap, the function automatically tries to pass load_sync_channel as an argument. However, this parameter is not valid for the legacy OpenEphys format, causing an error.

Proposed Fix
To prevent this error, the function should explicitly check whether the dataset follows the OpenEphys binary or legacy format before passing load_sync_channel.

Changes made in this PR:

Added a format check to load_data.
If the dataset is legacy, load_sync_channel is removed before calling the extractor.

## References
#186 

## How has this PR been tested?
To verify the fix, I attempted to create a dummy OpenEphys dataset that mimics both binary and legacy formats. However, during testing, I encountered an issue:

🚨 The OpenEphysBinaryRecordingExtractor does not detect any streams (stream_ids is empty), leading to:
IndexError: list index out of range.

Why?

The NeoBaseRecordingExtractor fetches stream_ids from self.neo_reader.header["signal_streams"], but the dummy data does not properly populate this.
Even though structure.oebin defines a stream, OpenEphysBinaryRecordingExtractor does not recognize it unless the exact file structure and metadata match real OpenEphys data.

🛠️ Next Steps

Confirm the fix in a real OpenEphys dataset
I can test this if provided with a valid dataset.
Improve dummy dataset generation

Currently, structure.oebin exists but may not be formatted exactly as required.
OpenEphys expects signal_streams and other metadata fields to be defined correctly.


**Would appreciate feedback on:**

Confirming the format check fix on a real dataset
Best approach to mock OpenEphys data for testing this issue


## Is this a breaking change?
No

## Does this PR require an update to the documentation?
No

## Checklist:

- [ ] The code has been tested locally
- [ ] Tests have been added to cover all new functionality
- [ ] The documentation has been updated to reflect any changes
- [ ] The code has been formatted with [pre-commit](https://pre-commit.com/)
