### PR TITLE
[Ref #162] Handle setting manual probes

### DIFF
--- a/spikewrap/process/_loading.py
+++ b/spikewrap/process/_loading.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
-from pathlib import Path  # Move Path outside TYPE_CHECKING
 from typing import TYPE_CHECKING, Literal
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     from spikeinterface.core import BaseRecording
 
 import re
@@ -112,14 +113,16 @@ def load_data(
 
     # Handle probe setting
     if probe is None:
-        _utils.message_user("⚠ No probe provided. Please select one manually.")
+        _utils.message_user("No probe provided. Please select one manually.")
         probe = choose_probe()
+        without_sync = without_sync.set_probe(probe)
 
     _utils.message_user(f"Using user-selected probe: {probe}")
 
     if probe is not None:
         if without_sync and without_sync.has_probe():
             _utils.message_user("Probe auto-detected. Using the detected probe.")
+            without_sync = without_sync.set_probe(probe)
         elif probe:
             _utils.message_user(
                 "No auto-detected probe found. Using the user-provided probe."


### PR DESCRIPTION
## Description
Implemented probe selection and manual setting functionality.
**What is this PR**

- [ ] Bug fix
- [x] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
This PR addresses the enhancement requested in issue #162 , which was related to handling the manual setting of probes

**What does this PR do?**
The following functionality has been implemented:

- **Probe selection functionality**: If no probe is auto-detected in the `load_data` function, the user is prompted to manually select a probe.
  - The user is asked to input the manufacturer (e.g., 'cambridgeneurotech', 'neuropixels', 'neuronexus').
  - The user then provides the specific probe name for the selected manufacturer (e.g., 'ASSY-37-E-1' for 'cambridgeneurotech').
  
- **Probe validation**: After the user inputs the probe details, the probe is validated by calling `get_probe()` from the `probeinterface` library, and the selected probe is set for the data.

- **Dummy `load_data` implementation**: As I couldn't yet get my hands on real data, this implementation simulates loading the data without actual processing. It provides a mock loading process, prints debug messages, and successfully sets the user-provided probe for the data.

- **Error Handling**: If the user provides an invalid manufacturer or probe, appropriate error messages are displayed and the process is halted, ensuring a smooth user experience.

## References
#162 

## Has this PR been tested?
- **Dummy `load_data` implementation**: As I couldn't yet get my hands on real data, this implementation simulates loading the data without actual processing. It provides a mock loading process, prints debug messages, and successfully sets the user-provided probe for the data.

**Check out the video here :** 

https://github.com/user-attachments/assets/f07dc3e5-39a8-4dd7-82a9-4b0477340e82

## Is this a breaking change?
No

## Does this PR require an update to the documentation?

If any features have changed, or have been added. Please explain how the
documentation has been updated.

## Checklist:

- [x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
