### PR TITLE
Fix API links within sync docs

### DIFF
--- a/docs/source/galleries/how_to/05_sync_channel.py
+++ b/docs/source/galleries/how_to/05_sync_channel.py
@@ -12,8 +12,8 @@ How to Edit the Sync Channel
 
 # %%
 # .. warning::
-#     Currently, the only supported sync channel is for Neuropixels data (in which it is
-#     the 385th channel). Please get in contact to see other cases supported.
+#     Currently, the only supported sync channel is from Neuropixels Imec stream
+#     (in which it is the 385th channel). Please get in contact to see other cases supported.
 
 
 import spikewrap as sw

--- a/docs/source/galleries/tutorials/04_spike_sorting.py
+++ b/docs/source/galleries/tutorials/04_spike_sorting.py
@@ -193,14 +193,17 @@ config_dict = {
 # The :class:`spikewrap.Session.sort` function will accept the name
 # of the stored config file, the full config dictionary such as above,
 # or the "sorting" sub-dictionary, e.g.:
+#
+# .. code-block:: python
+#
+#     sorting_dict = {"sorting": {"mountainsort5": {"filter": False}}}
+#
+#     session.sort(
+#         configs=sorting_dict, run_sorter_method="local"
+#     )
+#
 
-sorting_dict = {"sorting": {"mountainsort5": {"filter": False}}}
-
-session.sort(
-    configs=sorting_dict, run_sorter_method="local"
-)
-
-# %%  # `their documentation. <https://spikeinterface.readthedocs.io/en/stable/>`_,
+# %%
 # The sorter name (e.g. ``"mountainsort5"``) should make the
 # `SpikeInterface sorter name <https://spikeinterface.readthedocs.io/en/latest/modules/sorters.html#supported-spike-sorters>`_,
 # while the keyword-arguments should match the sorter-specific arguments.These can be found at the

--- a/docs/source/galleries/tutorials/05_sync_channel.py
+++ b/docs/source/galleries/tutorials/05_sync_channel.py
@@ -11,8 +11,8 @@ Sync Channel Tutorial
 """
 # %%
 # .. warning::
-#     Currently, the only supported sync channel is for Neuropixels data (in which it is
-#     the 385th channel). Please get in contact to see other cases supported.
+#     Currently, the only supported sync channel is from Neuropixels Imec stream
+#     (in which it is the 385th channel). Please get in contact to see other cases supported.
 #
 # Sync channels are used in extracellular electrophysiology to coordinate timestamps
 # from across acquisition devices.
@@ -29,7 +29,7 @@ Sync Channel Tutorial
 # Raw data must be loaded prior to working with the sync channel.
 # The sync channel for a particular run is specified with the ``run_idx``
 # parameter. Runs are accessed in the order they are loaded (as specified
-# with ``run_names``, see :func:`spikewrap.session.get_raw_run_names`.
+# with ``run_names``, see :class:`spikewrap.Session.get_raw_run_names`.
 #
 # In this toy example data, the sync channel is set to all ones (typically,
 # it would be all ``0`` interspersed with ``1`` indicating triggers).
@@ -97,8 +97,8 @@ plot = session.plot_sync_channel(run_idx=0, show=True)
 #
 # If runs are concatenated during preprocessing, the sync channel
 # will be concatenated. To see the sync channel after preprocessing,
-# use the function :func:`spikewrap.session.get_sync_channel_after_preprocessing`.
-
+# use the function :class:`spikewrap.Session.get_sync_channel_after_preprocessing`.
+#
 # Note that the sync channel itself is never preprocessed, and in the case
 # that concatenation is not performed, the sync channel on a preprocessed
 # run will be the same as the sync channel before preprocessing is performed.

--- a/spikewrap/structure/session.py
+++ b/spikewrap/structure/session.py
@@ -548,7 +548,9 @@ class Session:
             )
 
     def get_sync_channel_after_preprocessing(self, run_idx: int) -> None | np.ndarray:
-        """ """
+        """
+        Test
+        """
         if not any(self._pp_runs):
             raise RuntimeError(
                 "Preprocessing must be performed before running this function."


### PR DESCRIPTION
Small improvements to documentation, including fixing internal API docs links, some rewording, and reduce number of run examples for sorting to improve docs build time.