### PR TITLE
Uncouple sync and preprocessing

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,12 @@ session = sw.Session(
     probe=None,  # optional argument to set probe (neuropixels auto-detected)
 )
 
+session.save_sync_channel()
+
 session.preprocess(
     configs="neuropixels+kilosort2_5",
     per_shank=True,
-    concat_runs=True,
+    concat_runs=False,
 )
 
 session.save_preprocessed(
@@ -47,19 +49,20 @@ This will output a folder structure like:
 ```
 └── derivatives/
     └── sub-001/
-        └── ses-001  /
+        └── ses-001/
             └── ephys/
-                └── concat_run/
-                    ├── preprocessed/
-                    │   ├── shank_0/
-                    │   │   └── si_recording/
-                    │   │       └── <spikeinterface binary>
-                    │   └── shank_1/
-                    │       └── si_recording/
-                    │           └── <spikeinterface binary> 
-                    └── sync/
-                    │   └── sync_channel.npy
-                    └── orig_run_names.txt
+                ├── run-001/
+                │   ├── preprocessed/
+                │   │   ├── shank_0/
+                │   │   │   └── si_recording/
+                │   │   │       └── <spikeinterface binary>
+                │   │   └── shank_1/
+                │   │       └── si_recording/
+                │   │           └── <spikeinterface binary>      
+                │   └── sync/
+                │       └── sync_channel.npy
+                └── run-002/
+                    └── ...    
 ```                   
 
 ## Installation

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -218,6 +218,7 @@ notfound_context = {
 notfound_urls_prefix = None
 
 linkcheck_ignore = [
-    "https://github.com/SpikeInterface/*",  # to avoid odd 403 error
+    "https://github.com/SpikeInterface/*",
+    "https://github.com/billkarsh/CatGT/blob/1ad1abe894e07d5fa3cb0439961d162caba34628/Build/ReadMe.md?plain=1#L1121"
 ]
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -189,9 +189,6 @@ html_favicon = "_static/light-logo-niu.png"
 linkcheck_anchors_ignore_for_url = [
     "https://neuroinformatics.zulipchat.com"
 ]
-# A list of regular expressions that match URIs that should not be checked
-linkcheck_ignore = [
-]
 
 intersphinx_mapping = {
     "scipy": ("https://docs.scipy.org/doc/scipy/", None),
@@ -217,8 +214,9 @@ notfound_context = {
 # because we have no '/<language>/<version>/' in the URL
 notfound_urls_prefix = None
 
+# A list of regular expressions that match URIs that should not be checked
 linkcheck_ignore = [
     "https://github.com/SpikeInterface/*",
-    "https://github.com/billkarsh/CatGT/blob/1ad1abe894e07d5fa3cb0439961d162caba34628/Build/ReadMe.md?plain=1#L1121"
+    "https://github.com/billkarsh/CatGT/*"
 ]
 

--- a/docs/source/galleries/get_started/feature_overview.py
+++ b/docs/source/galleries/get_started/feature_overview.py
@@ -119,6 +119,7 @@ session = sw.Session(
     probe=None,  # optional argument to set probe
 )
 
+session.save_sync_channel()
 
 # Run (lazy) preprocessing, for fast plotting
 # and prototyping of preprocessing steps

--- a/docs/source/galleries/how_to/05_sync_channel.py
+++ b/docs/source/galleries/how_to/05_sync_channel.py
@@ -44,11 +44,4 @@ session.silence_sync_channel(
 # refresh the sync channel
 session.load_raw_data(overwrite=True)
 
-# The sync channel can be concatenated as part of the preprocessing
-session.preprocess("neuropixels+kilosort2_5", concat_runs=True)
-
-# the sync channel will only change after preprocessing if concatenation is used.
-concat_sync_channel = session.get_sync_channel_after_preprocessing(run_idx=0)
-
-# this is the sync channel that is saved with `save_preprocessed`:
-session.save_preprocessed(overwrite=True)
+session.save_sync_channel(overwrite=True, slurm=False)

--- a/docs/source/galleries/tutorials/04_spike_sorting.py
+++ b/docs/source/galleries/tutorials/04_spike_sorting.py
@@ -59,8 +59,6 @@ session.sort(
 #                         ├── concat_run/
 #                         │   ├── preprocessed/
 #                         │   │   └── <preprocessed_data>
-#                         │   ├── sync/
-#                         │   │   └── <sync_data>
 #                         │   └── sorting/
 #                         │       └── shank_0
 #                         │           └── ...

--- a/docs/source/galleries/tutorials/05_sync_channel.py
+++ b/docs/source/galleries/tutorials/05_sync_channel.py
@@ -12,7 +12,8 @@ Sync Channel Tutorial
 # --- hide: start ---
 import shutil
 import spikewrap as sw
-shutil.rmtree(sw.get_example_data_path("openephys") / "derivatives")
+if (derivatives_path := sw.get_example_data_path("openephys") / "derivatives").is_dir():
+    shutil.rmtree(derivatives_path)
 # --- hide: stop ---
 
 # %%

--- a/docs/source/galleries/tutorials/05_sync_channel.py
+++ b/docs/source/galleries/tutorials/05_sync_channel.py
@@ -18,8 +18,15 @@ Sync Channel Tutorial
 # from across acquisition devices.
 #
 # In ``spikewrap``, the sync channel can be inspected and edited. **This step
-# must be performed prior to preprocessing**, after which the sync channel
-# is split from the recording for saving.
+# must be performed prior to preprocessing**.
+#
+# .. warning::
+#
+#     ``spikewrap`` does not currently provide any methods for concatenating the sync channel.
+#     This is because a straightforward concatenation may be error prone
+#     `(see here for more details) <https://spikeinterface.readthedocs.io/en/latest/api.html#spikeinterface.preprocessing.silence_periods>`_.
+#     We are keen to extend sync-channel processing functionality, please get in contact with your use-case
+#     to help usc extend support.
 
 # %%
 # Inspecting the sync channel
@@ -29,7 +36,7 @@ Sync Channel Tutorial
 # Raw data must be loaded prior to working with the sync channel.
 # The sync channel for a particular run is specified with the ``run_idx``
 # parameter. Runs are accessed in the order they are loaded (as specified
-# with ``run_names``, see :class:`spikewrap.Session.get_raw_run_names`.
+# with ``run_names``, see :class:`spikewrap.Session.get_raw_run_names`).
 #
 # In this toy example data, the sync channel is set to all ones (typically,
 # it would be all ``0`` interspersed with ``1`` indicating triggers).
@@ -92,46 +99,18 @@ session.load_raw_data(overwrite=True)
 plot = session.plot_sync_channel(run_idx=0, show=True)
 
 # %%
-# Concatenating the sync channel
-# ------------------------------
-#
-# If runs are concatenated during preprocessing, the sync channel
-# will be concatenated. To see the sync channel after preprocessing,
-# use the function :class:`spikewrap.Session.get_sync_channel_after_preprocessing`.
-#
-# Note that the sync channel itself is never preprocessed, and in the case
-# that concatenation is not performed, the sync channel on a preprocessed
-# run will be the same as the sync channel before preprocessing is performed.
-#
-# The only difference is that if runs were concatenated before preprocessing,
-# the sync channel will now reflect this. In the below example, the sync channel
-# is now 2000 samples long (each run is 1000 samples long):
-
-session.preprocess("neuropixels+kilosort2_5", concat_runs=True)
-
-concat_sync_channel = session.get_sync_channel_after_preprocessing(run_idx=0)
-
-import matplotlib.pyplot as plt
-
-plt.plot(concat_sync_channel)
-plt.show()
-
-# %%
-# This is the sync channel that will be saved when :class:`spikewrap.Session.save_preprocessed` is called.
-
-# %%
 # Saving the sync channel
 # -----------------------
 #
-# The easiest way to manage sync channel saving is to let spikewrap save the sync
-# channel as part of :class:`spikewrap.Session.save_preprocessed`. Otherwise, it can get saved
-# manually after obtaining it from a getter function.
+# The sync channel can be saved with:
+
+session.save_sync_channel(overwrite=False, slurm=False)
+
+# %%
+# which will save the sync channel for all loaded runs to the run folder.
+# See the :ref:`SLURM tutorial <slurm-tutorial>` for more information on using slurm.
 #
-# .. note::
-#     Currently, the sync channel is saved after preprocessing, but not sorting. Therefore,
-#     if concatenating runs before sorting, this will not be reflected in the sync channel.
-#     Please get in contact if you would like to see this implemented.
-#
+
 
 
 

--- a/docs/source/galleries/tutorials/05_sync_channel.py
+++ b/docs/source/galleries/tutorials/05_sync_channel.py
@@ -9,6 +9,12 @@ Sync Channel Tutorial
     This is a long-form tutorial on sorting. See :ref:`here <sync-channel-howto>` for a quick how-to.
 
 """
+# --- hide: start ---
+import shutil
+import spikewrap as sw
+shutil.rmtree(sw.get_example_data_path("openephys") / "derivatives")
+# --- hide: stop ---
+
 # %%
 # .. warning::
 #     Currently, the only supported sync channel is from Neuropixels Imec stream

--- a/docs/source/get_started/output_folder_formats.md
+++ b/docs/source/get_started/output_folder_formats.md
@@ -18,42 +18,48 @@ However, the output folder can  be overridden by passing the ``output_path`` arg
 ## Runs concatenated, split by shank
 
 ```
-`
 └── derivatives/
     └── sub-001/
-        └── ses-001  /
+        └── ses-001/
             └── ephys/
+                ├── run-001_g0_imec0/
+                │   └── sync/
+                │       └── sync_channel.npy
+                ├── run_002_g0_imec0/
+                │   └── sync/
+                │       └── sync_channel.npy
                 └── concat_run/
                     ├── preprocessed/
                     │   ├── shank_0/
                     │   │   └── si_recording/
                     │   │       └── <spikeinterface binary>
                     │   └── shank_1/
-                    │       └── si_recording/
-                    │           └── <spikeinterface binary> 
-                    └── sync/
-                    │   └── sync_channel.npy
+                    │       └── ...
+                    ├── sorting/
+                    │   └── ...
                     └── orig_run_names.txt
-
 ```
 
 Here, the concatenated runs are stored in a folder with the canonical name
 ``concat_run``. The names of the original runs and their concatenation order
-are stored in ``orig_run_names.txt``.
+are stored in ``orig_run_names.txt``. Note that sync runs are always saved
+per-run and are not concatenated, to avoid [incorrect assumptions](https://github.com/billkarsh/CatGT/blob/1ad1abe894e07d5fa3cb0439961d162caba34628/Build/ReadMe.md?plain=1#L1121).
 
 ## No run concatenation, not split by shank
 
 ```
-   └── derivatives/
-       └── sub-001/
-           └── ses-001/
-               └── ephys/
-                   ├── run-001_g0_imec0/
-                   │   ├── preprocessed/
-                   │   │   └── si_recording/
-                   │   │       └── <spikeinterface binary>
-                   │   └── sync/
-                   │       └── sync_channel.npy
-                   └── run-002_g0_imec0/
-                       └── ...
+└── derivatives/
+    └── sub-001/
+        └── ses-001/
+            └── ephys/
+                ├── run-001_g0_imec0/
+                │   ├── preprocessed/
+                │   │   └── si_recording/
+                │   │       └── <spikeinterface binary>
+                │   ├── sync/
+                │   │   └── sync_channel.npy
+                │   └── sorting/
+                │       └── ...
+                └── run-001_g0_imec0/
+                    └── ...  
 ```

--- a/spikewrap/__init__.py
+++ b/spikewrap/__init__.py
@@ -26,7 +26,7 @@ from .configs.config_utils import (
 from .configs.hpc import default_slurm_options
 
 # TODO: there must be a better way!
-# this is necessary for doc api linking?
+# this is necessary for doc api linking? can I just remove!?!??
 __all__ = [
     "Session",
     "get_example_data_path",
@@ -45,5 +45,5 @@ __all__ = [
     "get_sync_channel",
     "plot_sync_channel",
     "silence_sync_channel",
-    "get_sync_channel_after_preprocessing",
+    "get_sync_channel",
 ]

--- a/spikewrap/structure/_raw_run.py
+++ b/spikewrap/structure/_raw_run.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import shutil
 from typing import TYPE_CHECKING, Literal
 
 if TYPE_CHECKING:
@@ -11,12 +12,13 @@ if TYPE_CHECKING:
     from spikeinterface.core import BaseRecording
 
 import matplotlib.pyplot as plt
+import numpy as np
 import spikeinterface.full as si
 
 from spikewrap.configs._backend import canon
 from spikewrap.process import _loading
 from spikewrap.process._preprocessing import _preprocess_recording  # TODO
-from spikewrap.utils import _utils
+from spikewrap.utils import _slurm, _utils
 
 
 class RawRun:
@@ -35,6 +37,9 @@ class RawRun:
         Path to the output (processed) parent session-level data.
     file_format
         "spikeglx" or "openephys", acquisition software used.
+    sync_output_path
+        For `SeparateRawRun`, where the sync channel is saved.
+        Should be same path as preprocessed data output.
 
     Notes
     -----
@@ -54,12 +59,14 @@ class RawRun:
         parent_ses_name: str,
         run_name: str,
         file_format: Literal["spikeglx", "openephys"],
+        sync_output_path: Path | None,
     ):
 
         self._parent_input_path = parent_input_path
         self._parent_ses_name = parent_ses_name
         self._run_name = run_name
         self._file_format = file_format
+        self._sync_output_path = sync_output_path  # TODO: this name is confusing because it seems like the folder to the sync path but it is just to the run output path... should probably rename a lot
 
         # _raw should not change throughout the lifetime of the class
         # self._sync may be edited in place.
@@ -201,6 +208,16 @@ class RawRun:
             if slurm:
                 self._save_sync_channel_slurm(overwrite, slurm)
 
+            sync_output_folder = self._sync_output_path / canon.sync_folder()
+
+            if sync_output_folder.is_dir():
+                if overwrite:
+                    shutil.rmtree(sync_output_folder)
+                else:
+                    raise RuntimeError(
+                        f"`overwrite=False` but sync data already exists at: {sync_output_folder}"
+                    )
+
             sync_data = self.get_sync_channel()
 
             _utils.message_user(f"Saving sync channel for: {self._run_name}...")
@@ -208,24 +225,27 @@ class RawRun:
             assert sync_data.size == self._raw["grouped"].get_num_samples()
 
             # Save the sync channel
-            sync_output_filepath = (
-                self._output_path / canon.sync_folder() / canon.saved_sync_filename()
-            )
-            sync_output_filepath.parent.mkdir(parents=True, exist_ok=True)
-            np.save(sync_output_filepath, sync_data)
+            assert self._sync_output_path is not None
 
-    def _save_sync_channel_slurm(self, overwrite, slurm):
+            sync_output_folder.mkdir(parents=True, exist_ok=True)
+            np.save(sync_output_folder / canon.saved_sync_filename(), sync_data)
+
+    def _save_sync_channel_slurm(self, overwrite: bool, slurm: dict | bool) -> None:
         """ """
         slurm_ops: dict | bool = slurm if isinstance(slurm, dict) else False
 
+        assert (
+            self._sync_output_path is not None
+        ), "SeparateRawRun only contains self._sync_output_path"
+
         _slurm.run_in_slurm(
             slurm_ops,
-            func_to_run=self.save_preprocessed,
+            func_to_run=self._save_sync_channel_slurm,
             func_opts={
                 "overwrite": overwrite,
                 "slurm": False,
             },
-            log_base_path=self._output_path,
+            log_base_path=self._sync_output_path,
         )
 
     # ---------------------------------------------------------------------------
@@ -276,15 +296,13 @@ class SeparateRawRun(RawRun):
         run_name: str,
         file_format: Literal["spikeglx", "openephys"],
         probe: Probe | None,
+        sync_output_path: Path,
     ):
         self._parent_input_path: Path
         self._probe = probe
 
         super(SeparateRawRun, self).__init__(
-            parent_input_path,
-            parent_ses_name,
-            run_name,
-            file_format,
+            parent_input_path, parent_ses_name, run_name, file_format, sync_output_path
         )
 
     def load_raw_data(self, internal_overwrite: bool = False) -> None:
@@ -326,6 +344,8 @@ class ConcatRawRun(RawRun):
        already been loaded as separate runs and concatenated.
     2) ``_orig_run_names`` holds the names of original, separate
        recordings in the order they were concatenated.
+    3) `sync_output_path` is `None` because sync channel is handled
+       at the separate-run level.
     """
 
     def __init__(
@@ -340,6 +360,7 @@ class ConcatRawRun(RawRun):
             parent_ses_name=parent_ses_name,
             run_name="concat_run",
             file_format=file_format,
+            sync_output_path=None,
         )
 
         # Get the recordings to concatenate

--- a/spikewrap/structure/session.py
+++ b/spikewrap/structure/session.py
@@ -531,6 +531,13 @@ class Session:
 
         self._raw_runs[run_idx].silence_sync_channel(periods_to_silence)
 
+    def save_sync_channels(self, overwrite: bool, slurm: dict | bool) -> None:
+        """
+        Save all loaded runs sync channel to disk.
+        """
+        for run in self._raw_runs:
+            run.save_sync_channel(overwrite, slurm)
+
     def _assert_sync_channel_checks(self):
         """ """
         if not any(self._raw_runs):

--- a/tests/test_integration/test_sync.py
+++ b/tests/test_integration/test_sync.py
@@ -141,7 +141,13 @@ class TestSorting(BaseTest):
             session.plot_sync_channel(0)
 
     def test_save_sync(self, session):
+        """
+        Test sync channel saves correctly
+        and the overwrite flag works as expected
+        """
 
+        # Load raw data, edit it, save and reload checking
+        # reloaded data is correct
         session.load_raw_data()
 
         session.silence_sync_channel(1, [(250, 500)])
@@ -158,3 +164,19 @@ class TestSorting(BaseTest):
         assert np.all(load_1_sync == 1)
         assert np.all(load_2_sync[:250] == 1)
         assert np.all(load_2_sync[250:500] == 0)
+
+        # Overwrite the sync data, then try and save
+        # (should raise error with overwrite false)
+        session.load_raw_data(overwrite=True)
+
+        with pytest.raises(RuntimeError):
+            session.save_sync_channel()  # overwrite False is expected default
+
+        # Now save it and check the overwritten
+        # sync data is saved
+        session.save_sync_channel(overwrite=True)
+
+        load_2_sync = np.load(
+            session._output_path / "recording2" / "sync" / "sync_channel.npy"
+        )
+        assert np.all(load_2_sync == 1)


### PR DESCRIPTION
Further to #202, this PR uncouples any relationship between sync channel processing and pre-proecssing. In the last PR, the sync channel was loaded into memory at the preprocessing stage as I didn't think it would be so slow, of course 1 channel `int16` for 3 hours is half a gig, so it was slow.

Also, it was confusing to mix preprocessing and sync-channel processing, because the sync channel is not preprocessed. The sync channel is held in the recording object on the `session._raw_runs` class but is no longer propagated to preprocessing.

Figuring out how best to handle the sync channel is ongoing in #207 #208, but for now having this implementation completely separate will make extending it must easier. 