### PR TITLE
Docs fast fix

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -20,7 +20,7 @@ clean:
 
 fast:
     @echo "Fast mode enabled"
-	@export SPHINXENV=fast
+    @export SPHINXENV=fast
 
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -19,7 +19,7 @@ clean:
 	rm -rf ./source/gallery_builds
 
 fast:
-	SPHINXENV := fast
+	@export SPHINXENV=fast; $(MAKE) $(MAKECMDGOALS)
 
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -19,11 +19,11 @@ clean:
 	rm -rf ./source/gallery_builds
 
 fast:
-    @echo "Fast mode enabled"
-    @export SPHINXENV=fast
+	@echo "Fast mode enabled"
+	$(eval export SPHINXENV=fast)
 
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile
-    @echo Running: $(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+	@echo Running: $(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -19,8 +19,8 @@ clean:
 	rm -rf ./source/gallery_builds
 
 fast:
-	@echo "Fast mode enabled"
-	@$(MAKE) SPHINXENV=fast
+    @echo "Fast mode enabled"
+	@export SPHINXENV=fast
 
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -19,7 +19,7 @@ clean:
 	rm -rf ./source/gallery_builds
 
 fast:
-	@export SPHINXENV=fast; $(MAKE) $(MAKECMDGOALS)
+	@export SPHINXENV=fast
 
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -13,15 +13,16 @@ BUILDDIR      = build
 help:
 	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
+fast:
+	override SPHINXENV := fast
+
 # Remove all generated files
 clean:
 	rm -rf ./build
 	rm -rf ./source/gallery_builds
 
-fast:
-	$(eval SPHINXOPTS += -t fast)
-
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile
+    @echo Running: $(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -19,7 +19,8 @@ clean:
 	rm -rf ./source/gallery_builds
 
 fast:
-	@export SPHINXENV=fast
+	@echo "Fast mode enabled"
+	@$(MAKE) SPHINXENV=fast
 
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -13,13 +13,13 @@ BUILDDIR      = build
 help:
 	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
-fast:
-	override SPHINXENV := fast
-
 # Remove all generated files
 clean:
 	rm -rf ./build
 	rm -rf ./source/gallery_builds
+
+fast:
+	SPHINXENV := fast
 
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -26,25 +26,21 @@ if errorlevel 9009 (
 
 if "%1" == "" goto help
 
-REM Check if "fast" is passed as an argument and update SPHINXOPTS
-for %%A in (%*) do (
-	if "%%A"=="fast" (
-        set SPHINXOPTS=%SPHINXOPTS% -t fast
-	)
-)
-
-:process_targets
-if "%1" == "fast" shift
 if "%1" == "clean" (
 	echo Removing auto-generated files...
 	rmdir /S /Q %BUILDDIR%
 	rmdir /S /Q %SOURCEDIR%\gallery_builds\
-) else (
-	%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+	shift
 )
 
-shift
-if not "%1" == "" goto process_targets
+if "%1" == "fast" (
+    set SPHINXENV=fast
+    echo "Fast mode enabled: SPHINXENV is now %SPHINXENV%"
+    shift
+)
+
+echo %SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
 
 goto end
 

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -29,11 +29,12 @@ if "%1" == "" goto help
 REM Check if "fast" is passed as an argument and update SPHINXOPTS
 for %%A in (%*) do (
 	if "%%A"=="fast" (
-		set SPHINXOPTS=%SPHINXOPTS% -t fast
+        set SPHINXOPTS=%SPHINXOPTS% -t fast
 	)
 )
 
 :process_targets
+if "%1" == "fast" shift
 if "%1" == "clean" (
 	echo Removing auto-generated files...
 	rmdir /S /Q %BUILDDIR%

--- a/docs/source/community/contributing_guidelines.md
+++ b/docs/source/community/contributing_guidelines.md
@@ -128,9 +128,11 @@ folder and open the `index.html` file.
 
 If running with fast mode :
 ```
-make clean html fast
+make fast clean html
 ```
 then any gallery with 'slow' in the filename will not be run, and run_stale_examples is set to False.
+
+Note the order is very important for this command, swapping argument order will result in an error.
 
 ### Editing the documentation
 

--- a/docs/source/community/contributing_guidelines.md
+++ b/docs/source/community/contributing_guidelines.md
@@ -128,7 +128,7 @@ folder and open the `index.html` file.
 
 If running with fast mode :
 ```
-make fast clean html
+make clean fast html
 ```
 then any gallery with 'slow' in the filename will not be run, and run_stale_examples is set to False.
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -105,9 +105,7 @@ exclude_patterns = [
     "gallery_builds/tutorials/*.ipynb", "gallery_builds/get_started/*.ipynb", "gallery_builds/how_to/*.ipynb"  # TODO: rename if not using custom
 ]
 
-import sphinx_gallery.sorting
-
-fast_mode = tags.has("fast")
+fast_mode = "fast" in os.getenv("SPHINXENV", "")
 
 # Configure Sphinx gallery
 sphinx_gallery_conf = {

--- a/docs/source/galleries/README.md
+++ b/docs/source/galleries/README.md
@@ -1,4 +1,0 @@
-If running with fast mode (make clean html fast)
-then any gallery with 'slow' in the filename
-will not be run, and run_stale_examples
-is set to False.

--- a/docs/source/get_started/index.md
+++ b/docs/source/get_started/index.md
@@ -15,7 +15,7 @@ How to install ``spikewrap``.
 :::
 
 :::{grid-item-card} {fas}`sitemap;sd-text-primary` Feature Overview
-:link: sphx_glr_gallery_builds_get_started_feature_overview.py
+:link: sphx_glr_gallery_builds_get_started_slow_feature_overview.py
 :link-type: ref
 
 Key features of the package.
@@ -45,7 +45,7 @@ How ``spikewrap`` outputs processed data.
 :hidden:
 
 installation
-../gallery_builds/get_started/feature_overview
+../gallery_builds/get_started/slow_feature_overview
 supported_formats
 output_folder_formats
 ```


### PR DESCRIPTION
An extension to #213, which worked but raised a weird sphinx warning under the hood.

Now, a tag is not used but instead an environment variable, which is read in the `conf.py`. The windows makefile now accepts the clean / fast tags to be in a certain order, so this is reflected in the docs.