### PR TITLE
Feature for displaying plotted figures after save_preprocessed() runs.

### DIFF
--- a/spikewrap/process/_preprocessing.py
+++ b/spikewrap/process/_preprocessing.py
@@ -29,6 +29,10 @@ def _preprocess_recording(
         {step_num_str : [preprocessing_func_name, {pp_func_args}]
     """
     pp_funcs = _get_pp_funcs()
+    try:
+        pp_step_names = list(pp_steps.values())
+    except Exception:
+        pp_step_names = []
 
     checked_pp_steps, pp_step_names = _check_and_sort_pp_steps(pp_steps, pp_funcs)
 
@@ -74,15 +78,13 @@ def _check_and_sort_pp_steps(pp_steps: dict, pp_funcs: dict) -> tuple[dict, list
         List of ordered preprocessing step names (e.g. "bandpass_filter").
     """
     _validate_pp_steps(pp_steps)
-    pp_step_names = [item[0] for item in pp_steps.values()]
-
-    # Check the preprocessing function names are valid and print steps used
+    pp_step_names = [step[0] for step in pp_steps.values()]
     canonical_step_names = list(pp_funcs.keys())
 
     for user_passed_name in pp_step_names:
         assert (
             user_passed_name in canonical_step_names
-        ), f"{user_passed_name} not in allowed names: ({canonical_step_names}"
+        ), f"{user_passed_name} not in allowed names: ({canonical_step_names})"
 
     return pp_steps, pp_step_names
 

--- a/spikewrap/structure/_preprocess_run.py
+++ b/spikewrap/structure/_preprocess_run.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+import os
 import shutil
 from typing import TYPE_CHECKING, Literal
 
+import matplotlib.pyplot as plt
 import yaml
 
 if TYPE_CHECKING:
@@ -92,7 +94,6 @@ class PreprocessedRun:
 
         self._handle_overwrite_output(overwrite)
 
-        # Save the recordings to disk, handling shank ids
         for shank_name, preprocessed_dict in self._preprocessed.items():
 
             preprocessed_path = self._output_path / canon.preprocessed_folder()
@@ -108,6 +109,23 @@ class PreprocessedRun:
                 folder=preprocessed_path,
                 chunk_duration=f"{chunk_duration_s}s",
             )
+
+        figure_path = preprocessed_path / "figures"
+        os.makedirs(figure_path, exist_ok=True)
+
+        figure, ax = plt.subplots(figsize=(10, 5))
+        si.plot_traces(
+            preprocessed_recording,
+            time_range=(0, 0.5),  # first 500ms
+            return_scaled=True,
+            show_channel_ids=False,
+            mode="line",
+            ax=ax,
+            segment_index=0,
+        )
+        ax.set_title(f"Preprocessed Data - {shank_name}")
+        plt.savefig(figure_path / f"{shank_name}preprocessed.png")
+        plt.close(figure)
 
         self.save_class_attributes_to_yaml(
             self._output_path / canon.preprocessed_folder()

--- a/spikewrap/structure/_raw_run.py
+++ b/spikewrap/structure/_raw_run.py
@@ -117,8 +117,12 @@ class RawRun:
         else:
             runs_to_preprocess = self._raw
 
+        if not runs_to_preprocess:
+            raise ValueError("ERROR: No data found in runs_to_preprocess!")
+
         preprocessed = {}
         for shank_id, raw_rec in runs_to_preprocess.items():
+
             prepro_dict = {"0-raw": raw_rec}
             preprocessed[shank_id] = _preprocess_recording(prepro_dict, pp_steps)
 


### PR DESCRIPTION
**What is this PR**

- [x] Addition of a new feature

**What does this PR do?**
- Added functionality to generate and display diagnostic plots after `save_preprocessed()` execution.

## References
Issue #216 

## How has this PR been tested?

1) Manually verified by running a test script that generates diagnostic plots.
2) Checked that all expected figures were created in the correct locations.
3) Pre-commit tests passed successfully.

## Is this a breaking change?

No this doesn't break any existing functionality.

## Does this PR require an update to the documentation?

No, unless the moderators feel the need to do so.

If any features have changed, or have been added. Please explain how the
documentation has been updated.

Documentation hasn't been updated, will do so asap, if required.

## Checklist:

- [x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
