### PR TITLE
perform an assert in test_slurm_sync

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "spikeinterface[full]==0.102.0",
+    "spikeinterface[full]==0.102.1",
     "submitit",
     "slurmio",
     "psutil",

--- a/tests/_tests_internal/_test_slurm.py
+++ b/tests/_tests_internal/_test_slurm.py
@@ -7,6 +7,7 @@ import pytest
 import spikeinterface.full as si
 
 import spikewrap as sw
+from spikewrap.configs._backend import canon
 
 # IN PROGRESS
 # TODO
@@ -43,6 +44,11 @@ class TestSlurmInternal:
         slurm_opts["wait"] = True
 
         session.save_sync_channel(slurm=slurm_opts)
+
+        for run in session._raw_runs:
+            sync_dir = run._sync_output_path / canon.sync_folder()
+            sync_file = sync_dir / canon.saved_sync_filename()
+            assert sync_file.exists(), f"Sync file {sync_file} not found."
 
     def test_slurm_prepro(self, teardown_derivatives_fixture):
         """ """


### PR DESCRIPTION
## Description  

**What is this PR**  

- [x] Bug fix  
- [ ] Addition of a new feature  
- [ ] Other  

**Why is this PR needed?**  
This PR ensures that the synchronization file is correctly saved by asserting its existence in the specified directory.  

**What does this PR do?**  
It adds an assertion statement inside a loop to verify that the expected sync file exists after calling `save_sync_channel()`.  

## References  

No existing issues or PRs referenced.  

## How has this PR been tested?  

Could not test it locally because I was not sure how to create a slurm on my system.

## Is this a breaking change?  

No. 

## Does this PR require an update to the documentation?  

No documentation update is required.  

## Checklist:  

- [ ] The code has been tested locally  
- [ ] Tests have been added to cover all new functionality  
- [ ] The documentation has been updated to reflect any changes  
- [x] The code has been formatted with [[pre-commit](https://pre-commit.com/)](https://pre-commit.com/)  

