### PR TITLE
Clipping python version to <3.13

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "spikewrap"
 authors = [{name = "Joe Ziminski", email= "joseph.j.ziminski@gmail.com"}]
 description = "Run extracellular electrophysiology analysis with SpikeInterface"
 readme = "README.md"
-requires-python = ">=3.9.0"
+requires-python = ">=3.9.0, <3.13"
 dynamic = ["version"]
 
 license = {text = "BSD-3-Clause"}


### PR DESCRIPTION
## Description  

**What is this PR**  

- [x] Bug fix  
- [ ] Addition of a new feature  
- [ ] Other  

**Why is this PR needed?**  
This PR addresses an issue where the virtual environment was created with Python 3.13.2, but `spikeinterface 0.102.0` has a requirement of Python <3.13, >=3.9.  

**What does this PR do?**  
It ensures compatibility by adjusting the Python version used in the environment to a supported version (Python <3.13).  

## References  
#230 

## How has this PR been tested?  

- The virtual environment has been recreated with a compatible Python version (`<3.13`).  python version fetched : Python 3.12.2 
- Dependencies have been reinstalled and verified for compatibility.  

## Is this a breaking change?  
No

## Does this PR require an update to the documentation?  
No

## Checklist:  

- [x] The code has been tested locally  
- [ ] Tests have been added to cover all new functionality  
- [ ] The documentation has been updated to reflect any changes  
- [x] The code has been formatted with [[pre-commit](https://pre-commit.com/)](https://pre-commit.com/)  
