### PR TITLE
Fix tcl error in tests

### DIFF
--- a/.github/workflows/lint_test_and_deploy.yml
+++ b/.github/workflows/lint_test_and_deploy.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest, ubuntu-latest, macos-latest]
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
     - uses: actions/checkout@v3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "spikewrap"
 authors = [{name = "Joe Ziminski", email= "joseph.j.ziminski@gmail.com"}]
 description = "Run extracellular electrophysiology analysis with SpikeInterface"
 readme = "README.md"
-requires-python = ">=3.9.0, <3.13"
+requires-python = ">=3.9.0, <3.14"
 dynamic = ["version"]
 
 license = {text = "BSD-3-Clause"}
@@ -16,6 +16,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Operating System :: OS Independent",
     "License :: OSI Approved :: BSD License",
 ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,9 @@
+import sys
+
+# There is a bug in Python 3.12/tcl/windows that leads to intermittent errors in tests, as described below:
+# https://stackoverflow.com/questions/71443540/intermittent-pytest-failures-complaining-about-missing-tcl-files-even-though-the
+# A quick workaround is to use a non-tkinter backend for the tests in this case.
+if sys.version_info >= (3, 12):
+    import matplotlib
+
+    matplotlib.use("Agg")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,6 @@
-import sys
-
 # There is a bug in Python 3.12/tcl/windows that leads to intermittent errors in tests, as described below:
 # https://stackoverflow.com/questions/71443540/intermittent-pytest-failures-complaining-about-missing-tcl-files-even-though-the
 # A quick workaround is to use a non-tkinter backend for the tests in this case.
-if sys.version_info >= (3, 12):
-    import matplotlib
+import matplotlib
 
-    matplotlib.use("Agg")
+matplotlib.use("Agg")

--- a/tests/test_integration/test_sorting.py
+++ b/tests/test_integration/test_sorting.py
@@ -292,7 +292,7 @@ class TestSorting(BaseTest):
         sys.platform == "darwin", reason="Isoplit not installing on macOS"
     )
     @pytest.mark.parametrize("prepro_per_shank", [True, False])
-    def test_load_prepro_from_file_for_sorting(self, prepro_per_shank):
+    def test_load_prepro_from_file_for_sorting(self, tmpdir, prepro_per_shank):
         """
         Test when session is created without preprocessing, the preprocessed
         data should be loaded from file for sorting.
@@ -305,6 +305,7 @@ class TestSorting(BaseTest):
             session._file_format,
             session._passed_run_names,
             probe=session._probe,
+            output_path=tmpdir,
         )
         assert session.get_preprocessed_run_names() == []
 


### PR DESCRIPTION
Use headless backend for plotting in test environment to fix intermitted tcl errors on Windows, as described [here](https://stackoverflow.com/questions/71443540/intermittent-pytest-failures-complaining-about-missing-tcl-files-even-though-the).